### PR TITLE
interface-update. Restart wg0 VPN

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -45,3 +45,13 @@ event_services($event, qw(
     wg-quick@wg0 restart
     agent restart
 ));
+
+#
+# interface-update event
+#
+
+$event = "interface-update";
+
+event_services($event, qw(
+    wg-quick@wg0 restart
+));


### PR DESCRIPTION
The WireGuard tunnel is unresponsive when interface-update is signaled. The wg0 restart should fix the problem.
