### PR TITLE
Add z-push state directory in the webtop migration

### DIFF
--- a/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-webtop5/bind.env
+++ b/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-webtop5/bind.env
@@ -1,3 +1,3 @@
 # This file is included by ns8-bind-app
-MODULE_VOLUMES="webtop-home"
+MODULE_VOLUMES="webtop-home z-push_state"
 MODULE_IMAGE_URL="ghcr.io/nethserver/webtop:main"

--- a/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-webtop5/migrate
+++ b/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-webtop5/migrate
@@ -43,6 +43,16 @@ if [[ "${MIGRATE_ACTION}" == "finish" ]]; then
     systemctl stop tomcat8@webtop
 fi
 
+# Check if the ActiveSyncLegacyIds is enabled
+legacy_ids=$(/sbin/e-smith/config getprop webtop ActiveSyncLegacyIds)
+if [[ "${legacy_ids}" == "enabled" ]]; then
+	touch legacy_ids_enabled
+	rsync -i --remove-source-files legacy_ids_enabled "${RSYNC_ENDPOINT}"/data/state/
+fi
+
+# Sync z-push_state
+rsync -i --times --recursive --delete /var/log/z-push/state/ "${RSYNC_ENDPOINT}"/data/volumes/z-push_state/
+
 # Sync postgresql webtop5 DB dump
 su - postgres -c "pg_dump --format=c webtop5" > webtop5.dump
 rsync -zi webtop5.dump "${RSYNC_ENDPOINT}"/data/state/webtop5.dump


### PR DESCRIPTION
If the db prop `ActiveSyncLegacyIds` is enabled, the value will be preserved in the migration.

Related PR: NethServer/ns8-webtop#13