### PR TITLE
mail: avoid failure

### DIFF
--- a/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-mail/migrate
+++ b/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-mail/migrate
@@ -65,7 +65,8 @@ rsync -i --remove-source-files user_domain.txt mail_domain.txt {users,groups,dom
 if [[ "${MIGRATE_ACTION}" == "finish" ]]; then
     # During the last, "finish" rsync run there must be no changes to
     # contents of maildirs: stop the services early.
-    systemctl stop postfix dovecot rspamd
+    systemctl stop postfix dovecot
+    systemctl stop rspamd || : # rspamd could be not installed
 fi
 
 # rsync note: using usermap and groupmap arguments because the chown does
@@ -98,7 +99,7 @@ for service in rspamd postfix dovecot opendkim olefy; do
 done
 
 # Commit Mail migration
-rsync "${RSYNC_ENDPOINT}"/terminate
+rsync "${RSYNC_ENDPOINT}"/terminate || :
 
 # Wait until the import-module task has completed
 ns8-action --attach wait "${IMPORT_TASK_ID}"


### PR DESCRIPTION
Do not fail if rspamd is not installed and if rsync is not still terminated.