### PR TITLE
Fix samba migration

### DIFF
--- a/root/etc/e-smith/templates/var/lib/machines/nsdc/etc/systemd/network/green.network/20wg_route
+++ b/root/etc/e-smith/templates/var/lib/machines/nsdc/etc/systemd/network/green.network/20wg_route
@@ -1,0 +1,13 @@
+{
+    use esmith::NetworksDB;
+    my $ndb = esmith::NetworksDB->open();
+    my $network = ${'wg-quick@wg0'}{'RemoteNetwork'} || '';
+    my $bridge = $nsdc{'bridge'} || die ("[ERROR] There is no network bridge for NethServer domain controller");
+    my $gateway = $ndb->get_prop($bridge, 'ipaddr') || '';
+ 
+   if ($network ne '' && $gateway ne '') {
+       $OUT .= "[Route]\n";
+       $OUT .= "Destination=$network\n";
+       $OUT .= "Gateway=$gateway\n";
+   }
+}

--- a/root/usr/sbin/ns8-join
+++ b/root/usr/sbin/ns8-join
@@ -174,6 +174,17 @@ if account_provider_config['isAD'] == '1':
         if update_routes_response['data']['exit_code'] != 0:
             print("Task update_routes has failed:", update_routes_response, file=sys.stderr)
             sys.exit(1)
+        # Update nsdc route for wireguard VPN
+        subprocess.run(['/sbin/e-smith/expand-template', '/var/lib/machines/nsdc/etc/systemd/network/green.network'], check=True)
+        subprocess.run(['systemctl', 'restart', 'nsdc'], check=True)
+        # wait for nsdc to start
+        watchdog = 0
+        while subprocess.run(['/usr/bin/nc', '-z', nsdc_ip_address, '636']).returncode != 0:
+            time.sleep(1)
+            watchdog = watchdog + 1
+            if watchdog > 60: # wait max 60 seconds
+                print("nsdc restart has failed", file=sys.stderr)
+                sys.exit(1)
         # Configure NSDC as account provider of an external user domain:
         add_external_domain_request = {
             "domain": account_provider_domain,

--- a/root/usr/sbin/ns8-join
+++ b/root/usr/sbin/ns8-join
@@ -169,7 +169,7 @@ if account_provider_config['isAD'] == '1':
         pass # Ignore missing nsdc/IpAddress prop
     else:
         # Push a route to reach NSDC IP address through the cluster VPN
-        update_routes_request = {"add": [{"network": nsdc_ip_address + '/32', "node_id": ret['node_id']}]}
+        update_routes_request = {"add": [{"ip_address": nsdc_ip_address, "node_id": ret['node_id']}]}
         update_routes_response = call(api_endpoint, "update-routes", payload['token'], update_routes_request, False)
         if update_routes_response['data']['exit_code'] != 0:
             print("Task update_routes has failed:", update_routes_response, file=sys.stderr)

--- a/root/usr/sbin/ns8-join
+++ b/root/usr/sbin/ns8-join
@@ -176,15 +176,7 @@ if account_provider_config['isAD'] == '1':
             sys.exit(1)
         # Update nsdc route for wireguard VPN
         subprocess.run(['/sbin/e-smith/expand-template', '/var/lib/machines/nsdc/etc/systemd/network/green.network'], check=True)
-        subprocess.run(['systemctl', 'restart', 'nsdc'], check=True)
-        # wait for nsdc to start
-        watchdog = 0
-        while subprocess.run(['/usr/bin/nc', '-z', nsdc_ip_address, '636']).returncode != 0:
-            time.sleep(1)
-            watchdog = watchdog + 1
-            if watchdog > 60: # wait max 60 seconds
-                print("nsdc restart has failed", file=sys.stderr)
-                sys.exit(1)
+        subprocess.run(['systemctl', '-M', 'nsdc', 'restart', 'systemd-networkd'], check=True)
         # Configure NSDC as account provider of an external user domain:
         add_external_domain_request = {
             "domain": account_provider_domain,

--- a/root/usr/sbin/ns8-leave
+++ b/root/usr/sbin/ns8-leave
@@ -35,6 +35,12 @@ fi
 /sbin/e-smith/config setprop agent status disabled
 /sbin/e-smith/config setprop wg-quick@wg0 status disabled Address "" RemoteEndpoint "" RemoteKey "" RemoteNetwork ""
 
+# reset nsdc routes
+if [ -f /var/lib/machines/nsdc/etc/systemd/network/green.network ]; then
+    /sbin/e-smith/expand-template /var/lib/machines/nsdc/etc/systemd/network/green.network
+    systemctl restart nsdc
+fi
+
 # clean up agent state directory
 find /var/lib/nethserver/nethserver-ns8-migration -type f -not -name index.html | xargs -- rm -vf
 

--- a/root/usr/sbin/ns8-leave
+++ b/root/usr/sbin/ns8-leave
@@ -38,7 +38,7 @@ fi
 # reset nsdc routes
 if [ -f /var/lib/machines/nsdc/etc/systemd/network/green.network ]; then
     /sbin/e-smith/expand-template /var/lib/machines/nsdc/etc/systemd/network/green.network
-    systemctl restart nsdc
+    systemctl -M nsdc restart systemd-networkd
 fi
 
 # clean up agent state directory

--- a/root/usr/share/nethesis/nethserver-ns8-migration/apps/account-provider/ad/bind.env
+++ b/root/usr/share/nethesis/nethserver-ns8-migration/apps/account-provider/ad/bind.env
@@ -1,3 +1,3 @@
 # This file is included by ns8-bind-app
 MODULE_VOLUMES="data"
-MODULE_IMAGE_URL="ghcr.io/nethserver/samba:0.0.4"
+MODULE_IMAGE_URL="ghcr.io/nethserver/samba:0.0.7"

--- a/root/usr/share/nethesis/nethserver-ns8-migration/apps/account-provider/ad/migrate
+++ b/root/usr/share/nethesis/nethserver-ns8-migration/apps/account-provider/ad/migrate
@@ -48,7 +48,7 @@ EOF
 rsync -i import.env "${RSYNC_ENDPOINT:?}"/data/state/import.env
 
 # Send sysvol contents
-rsync -ai /var/lib/machines/nsdc/var/lib/samba/sysvol/ "${RSYNC_ENDPOINT}"/data/volumes/data/sysvol/
+rsync -rlptDi /var/lib/machines/nsdc/var/lib/samba/sysvol/ "${RSYNC_ENDPOINT}"/data/volumes/data/sysvol/
 
 # Generate .export files, like the pre-backup event handler of NSDC does
 # shellcheck disable=SC2016


### PR DESCRIPTION
* join: do not use CIDR notation for samba
* setup route for nsdc

Requires: https://github.com/NethServer/ns8-samba/pull/11

Before merge, update Samba image to latest available tag.

See also https://trello.com/c/c9CGnMdR/331-migration-tool-p1-test-openldap-and-samba-migration