### PR TITLE
samba: support IP address parameters

### DIFF
--- a/api/migration/ad-helper
+++ b/api/migration/ad-helper
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+if [ -f /var/lib/nethserver/nethserver-ns8-migration/account-provider/ad/bind.env ]; then
+    source /var/lib/nethserver/nethserver-ns8-migration/account-provider/ad/bind.env
+    /usr/sbin/ns8-action module/$MODULE_INSTANCE_ID get-defaults '{"provision": "new-domain"}' | jq -r '.data.output.ipaddress_list // empty'
+fi

--- a/api/migration/read
+++ b/api/migration/read
@@ -63,19 +63,34 @@ def get_migration_status(app_id):
         return "not_migrated"
 
 def get_account_provider_info():
+    provider = 'ldap'
+    ip_addresses = []
+    if os.path.isfile('/etc/e-smith/db/configuration/defaults/nsdc/type'):
+        provider = 'ad'
+        process = subprocess.Popen('/usr/libexec/nethserver/api/nethserver-ns8-migration/migration/ad-helper', stdout=subprocess.PIPE)
+        output, error = process.communicate()
+        try:
+            ip_addresses = simplejson.loads(output)
+        except:
+            pass
+
     return {
-        "id": "account-provider"
+        "id": "account-provider",
+        "provider": provider,
+        "ip_addresses": ip_addresses
     }
 
 
 def get_nextcloud_info():
-    config = get_config("nextcloud")
-
-    return {
-        "id": "nethserver-nextcloud",
-        "name": "Nextcloud",
-        "config": config
-    }
+    if os.path.isfile('/etc/e-smith/db/configuration/defaults/nextcloud/type'):
+        config = get_config("nextcloud")
+        return {
+            "id": "nethserver-nextcloud",
+            "name": "Nextcloud",
+            "config": config
+        }
+    else:
+        return None
 
 
 def get_mattermost_info():

--- a/root/usr/share/nethesis/nethserver-ns8-migration/apps/account-provider/ad/migrate
+++ b/root/usr/share/nethesis/nethserver-ns8-migration/apps/account-provider/ad/migrate
@@ -23,8 +23,9 @@
 set -e
 
 # Read nsdc props
-IFS=$'\t' read -r provision_type ipaddress < <( /sbin/e-smith/config printjson nsdc | \
+IFS=$'\t' read -r provision_type cur_ipaddress < <( /sbin/e-smith/config printjson nsdc | \
     jq -r '.props | [.ProvisionType, .IpAddress] | join("\t") ' )
+ipaddress=${SAMBA_IPADDRESS:-$cur_ipaddress}
 
 # Read sssd props
 IFS=$'\t' read -r nbdomain realm svcuser svcpass < <( /sbin/e-smith/config printjson sssd | \

--- a/root/usr/share/nethesis/nethserver-ns8-migration/apps/account-provider/input-finish.jq
+++ b/root/usr/share/nethesis/nethserver-ns8-migration/apps/account-provider/input-finish.jq
@@ -1,0 +1,4 @@
+#
+# Assign environment variables from UI input -- jq filter
+#
+"SAMBA_IPADDRESS=" + .sambaIpAddress

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -554,9 +554,9 @@
                           <option
                             v-for="(ip, i) in adIpAddresses"
                             v-bind:key="i"
-                            :value="ip"
+                            :value="ip.ipaddress"
                           >
-                            {{ ip }}
+                            {{ ip.ipaddress }} - {{ ip.label }}
                           </option>
                         </select>
                         <span v-if="error.adIpAddress" class="help-block">{{
@@ -1173,6 +1173,13 @@ export default {
         const location = this.accountProviderConfig.location;
         accountProviderApp.name = this.$t(`dashboard.${location}_${type}`);
       }
+
+      apps.forEach(app => {
+        if (app.id === "account-provider" && app.provider === "ad") {
+          this.adIpAddresses = app.ip_addresses;
+        }
+      });
+
       this.apps = apps;
       this.loading.migrationRead = false;
     },
@@ -1227,6 +1234,8 @@ export default {
             migrationConfig.webtopVirtualHost = this.webtopVirtualHost;
           }
           migrationObj.migrationConfig = migrationConfig;
+        } else if (app.id === "account-provider" && app.provider === "ad") {
+          migrationObj.migrationConfig = {"sambaIpAddress": this.adIpAddress};
         }
       }
 


### PR DESCRIPTION
Allow to change the IP address during migration:
the NS8 node could not have the same IP address of the original server

Usage example:
```
echo '{"app":"account-provider","action":"finish", "migrationConfig": {"sambaIpAddress": "10.133.0.5"}}' | /usr/libexec/nethserver/api/nethserver-ns8-migration/migration/update
```

https://trello.com/c/c9CGnMdR/331-migration-tool-p1-test-openldap-and-samba-migration