### PR TITLE
api & ui: allow application skip

### DIFF
--- a/api/migration/read
+++ b/api/migration/read
@@ -53,12 +53,15 @@ def get_migration_status(app_id):
     migrating_flag = "/var/lib/nethserver/nethserver-ns8-migration/%s/bind.env" % app_id
     migrated_flag = "/var/lib/nethserver/nethserver-ns8-migration/%s/migrated" % app_id
     syncing_flag = "/var/lib/nethserver/nethserver-ns8-migration/%s/syncing.lock" % app_id
+    skip_flag = "/var/lib/nethserver/nethserver-ns8-migration/%s/skip" % app_id
     if os.path.exists(migrated_flag):
         return "migrated"
     elif is_locked(syncing_flag):
         return "syncing"
     elif os.path.exists(migrating_flag):
         return "migrating"
+    elif os.path.exists(skip_flag):
+        return "skipped"
     else:
         return "not_migrated"
 

--- a/api/migration/update
+++ b/api/migration/update
@@ -71,6 +71,8 @@ elif [[ "$action" == "finish" ]]; then
     fi
 elif [[ "$action" == "abort" ]]; then
     /usr/sbin/ns8-abort "${app_id}" &> /dev/null
+elif [[ "$action" == "toggle-skip" ]]; then
+    /usr/sbin/ns8-toggle-skip "${app_id}"
 else
     error "ApiFailed" "unknown action ${action}"
 fi

--- a/root/usr/sbin/ns8-toggle-skip
+++ b/root/usr/sbin/ns8-toggle-skip
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+set -e
+
+source /etc/nethserver/agent.env
+
+module=$1
+skip_file="${AGENT_STATE_DIR}/$module/skip"
+
+if [ -z "$module" ]; then
+    exit 1
+fi
+
+if [ -f "$skip_file" ]; then
+    rm -f "$skip_file"
+else
+    touch "$skip_file"
+fi

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -85,7 +85,10 @@
     "abort_current_app": "Would you like to abort the migration of {app} application? If you change your mind you can restart the migration later.",
     "error_on_abort": "There was an error during the abort procedure.",
     "external_user_domain_error": "This machine uses an external account provider. Before starting the migration, you must configure the same external user domain inside NS8 cluster.",
-    "internal_user_domain_error": "The NS8 cluster already has a user domain for the '{domain}' domain. Before starting the migration, remove the '{domain}' domain from the NS8 cluster."
+    "internal_user_domain_error": "The NS8 cluster already has a user domain for the '{domain}' domain. Before starting the migration, remove the '{domain}' domain from the NS8 cluster.",
+    "skip": "Skip migration",
+    "status_skipped": "This application will not be migrated",
+    "no_skip": "Enable migration"
   },
   "validation": {
     "leader_node_empty": "Leader node is required",

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -88,7 +88,8 @@
     "internal_user_domain_error": "The NS8 cluster already has a user domain for the '{domain}' domain. Before starting the migration, remove the '{domain}' domain from the NS8 cluster.",
     "skip": "Skip migration",
     "status_skipped": "This application will not be migrated",
-    "no_skip": "Enable migration"
+    "no_skip": "Enable migration",
+    "error_on_skip": "There was an error when changing the skip flag."
   },
   "validation": {
     "leader_node_empty": "Leader node is required",

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -232,7 +232,7 @@
               </button>
               <button
                   @click="toggleSkip(app)"
-                  :disabled="loading.migrationUpdate || app.status == 'syncing' || app.status == 'migrating' || accountProviderMigrationStarted"
+                  :disabled="loading.migrationUpdate || accountProviderMigrationStarted"
                   class="btn btn-default"
                 >
                   {{ app.status == 'skipped' ? $t("dashboard.no_skip") : $t("dashboard.skip") }}

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -190,7 +190,11 @@
             $t("dashboard.account_provider_migration_in_progress_description")
           }}
         </div>
-        <div id="pf-list-default" class="list-group list-view-pf app-list" v-if="validUserDomains">
+        <div
+          id="pf-list-default"
+          class="list-group list-view-pf app-list"
+          v-if="validUserDomains"
+        >
           <div v-for="app in apps" :key="app.id" class="list-group-item">
             <div class="list-view-pf-actions migration-buttons">
               <!-- local account provider -->
@@ -222,21 +226,31 @@
                 {{ $t("dashboard.start_migration") }}
               </button>
               <!-- other apps -->
-              <template v-else-if="app.status == 'not_migrated' || app.status == 'skipped'">
-              <button
-                @click="showStartMigrationModal(app)"
-                :disabled="isStartMigrationButtonDisabled(app)"
-                class="btn btn-default"
+              <template
+                v-else-if="
+                  app.status == 'not_migrated' || app.status == 'skipped'
+                "
               >
-                {{ $t("dashboard.start_migration") }}
-              </button>
-              <button
-                  @click="toggleSkip(app)"
-                  :disabled="loading.migrationUpdate || accountProviderMigrationStarted"
+                <button
+                  @click="showStartMigrationModal(app)"
+                  :disabled="isStartMigrationButtonDisabled(app)"
                   class="btn btn-default"
                 >
-                  {{ app.status == 'skipped' ? $t("dashboard.no_skip") : $t("dashboard.skip") }}
-              </button>
+                  {{ $t("dashboard.start_migration") }}
+                </button>
+                <button
+                  @click="toggleSkip(app)"
+                  :disabled="
+                    loading.migrationUpdate || accountProviderMigrationStarted
+                  "
+                  class="btn btn-default"
+                >
+                  {{
+                    app.status == "skipped"
+                      ? $t("dashboard.no_skip")
+                      : $t("dashboard.skip")
+                  }}
+                </button>
               </template>
               <template
                 v-else-if="app.status == 'migrating' || app.status == 'syncing'"
@@ -280,7 +294,7 @@
                 />
                 <img
                   v-else
-                  :class="['apps-icon', {'skipped': (app.status == 'skipped')}]"
+                  :class="['apps-icon', { skipped: app.status == 'skipped' }]"
                   :src="'../' + app.id + '/' + (app.icon || 'logo.png')"
                   @error="$event.target.src = 'logo.png'"
                 />
@@ -736,30 +750,34 @@
         <div class="modal-content">
           <div class="modal-header">
             <h4 class="modal-title">
-              {{ $t("dashboard.abort") }}: {{abortApp ? abortApp.name : ''}}
+              {{ $t("dashboard.abort") }}: {{ abortApp ? abortApp.name : "" }}
             </h4>
           </div>
           <form class="form-horizontal">
             <div class="modal-body">
               <div
-                v-html="$t('dashboard.abort_current_app', {app: abortApp ? abortApp.name : ''})"
+                v-html="
+                  $t('dashboard.abort_current_app', {
+                    app: abortApp ? abortApp.name : '',
+                  })
+                "
               ></div>
             </div>
             <div class="modal-footer">
-                <button
-                  type="button"
-                  class="btn btn-default"
-                  @click="hideAbortModal"
-                >
-                  {{ $t("cancel") }}
-                </button>
-                <button
-                  type="button"
-                  class="btn btn-danger"
-                  @click="abort(abortApp)"
-                >
-                  {{ $t("dashboard.abort") }}
-                </button>
+              <button
+                type="button"
+                class="btn btn-default"
+                @click="hideAbortModal"
+              >
+                {{ $t("cancel") }}
+              </button>
+              <button
+                type="button"
+                class="btn btn-danger"
+                @click="abort(abortApp)"
+              >
+                {{ $t("dashboard.abort") }}
+              </button>
             </div>
           </form>
         </div>
@@ -888,7 +906,7 @@ export default {
         getClusterStatus: "",
         roundCubeVirtualHost: "",
         webtopVirtualHost: "",
-        userDomains: ""
+        userDomains: "",
       },
     };
   },
@@ -929,7 +947,7 @@ export default {
             "nethserver-webtop5",
           ].includes(app.id)
       );
-    }
+    },
   },
   mounted() {
     this.connectionRead();
@@ -1250,7 +1268,7 @@ export default {
         accountProviderApp.name = this.$t(`dashboard.${location}_${type}`);
       }
 
-      apps.forEach(app => {
+      apps.forEach((app) => {
         if (app.id === "account-provider" && app.provider === "ad") {
           this.adIpAddresses = app.ip_addresses;
         }
@@ -1259,10 +1277,15 @@ export default {
       this.apps = apps;
       this.validUserDomains = output.validDomains;
       if (!this.validUserDomains) {
-        if (this.accountProviderConfig.location === 'remote') {
-           this.error.userDomains = this.$t("dashboard.external_user_domain_error");
+        if (this.accountProviderConfig.location === "remote") {
+          this.error.userDomains = this.$t(
+            "dashboard.external_user_domain_error"
+          );
         } else {
-           this.error.userDomains = this.$t("dashboard.internal_user_domain_error", {"domain": this.localDomain});
+          this.error.userDomains = this.$t(
+            "dashboard.internal_user_domain_error",
+            { domain: this.localDomain }
+          );
         }
       }
       this.loading.migrationRead = false;
@@ -1300,7 +1323,6 @@ export default {
       } else if (action === "finish") {
         // set migration configurations if needed
 
-
         if (app.id === "nethserver-nextcloud") {
           // if nextcloud virtualhost is already set, just uset it
           if (!this.virtualHost && this.nextcloudApp.config.props.VirtualHost) {
@@ -1319,7 +1341,7 @@ export default {
           }
           migrationObj.migrationConfig = migrationConfig;
         } else if (app.id === "account-provider" && app.provider === "ad") {
-          migrationObj.migrationConfig = {"sambaIpAddress": this.adIpAddress};
+          migrationObj.migrationConfig = { sambaIpAddress: this.adIpAddress };
         }
       }
 
@@ -1395,7 +1417,7 @@ export default {
         ["nethserver-ns8-migration/migration/update"],
         {
           action: "abort",
-          app: app.id
+          app: app.id,
         },
         null,
         function(success) {
@@ -1403,9 +1425,7 @@ export default {
           context.loading.migrationUpdate = false;
         },
         function(error) {
-          const errorMessage = context.$i18n.t(
-            "dashboard.error_on_abort"
-          );
+          const errorMessage = context.$i18n.t("dashboard.error_on_abort");
           console.error(errorMessage, error);
           context.error.migrationUpdate = errorMessage;
           context.loading.migrationUpdate = false;
@@ -1421,7 +1441,7 @@ export default {
         ["nethserver-ns8-migration/migration/update"],
         {
           action: "toggle-skip",
-          app: app.id
+          app: app.id,
         },
         null,
         function(success) {
@@ -1429,9 +1449,7 @@ export default {
           context.loading.migrationUpdate = false;
         },
         function(error) {
-          const errorMessage = context.$i18n.t(
-            "dashboard.error_on_skip"
-          );
+          const errorMessage = context.$i18n.t("dashboard.error_on_skip");
           console.error(errorMessage, error);
           context.error.migrationUpdate = errorMessage;
           context.loading.migrationUpdate = false;
@@ -1463,7 +1481,9 @@ export default {
             accountProviderConfig.type = "none";
           }
 
-          context.localDomain = accountProviderConfig.BaseDN ? accountProviderConfig.BaseDN.substring(3).replaceAll(",dc=",".") : "";
+          context.localDomain = accountProviderConfig.BaseDN
+            ? accountProviderConfig.BaseDN.substring(3).replaceAll(",dc=", ".")
+            : "";
           // provider location
 
           const location = accountProviderConfig.IsLocal ? "local" : "remote";


### PR DESCRIPTION
The "Skip migration" button is available only for applications. It is enabled only if:
- the migration of the app has not been already started
- the account provider migration has not been started

The account provider can be migrated when all applications are migrated or skipped.

See https://trello.com/c/kppKjWYd/334-migration-p2-skip-applications

Screencast: [Screencast from 2023-03-21 16-46-56.webm](https://user-images.githubusercontent.com/804596/226670504-89d85a67-1679-4a33-8113-8a5f33df1dc6.webm)
