### PR TITLE
Manage mail group all together

### DIFF
--- a/api/migration/update
+++ b/api/migration/update
@@ -70,6 +70,12 @@ elif [[ "$action" == "finish" ]]; then
         /usr/sbin/ns8-leave
     fi
 elif [[ "$action" == "abort" ]]; then
+    if [[ "${app_id}" == "nethserver-mail" ]]; then
+        # Abort also roundcube and webtop migration: both apps must be migrated
+        # together with the mail server
+        /usr/sbin/ns8-abort nethserver-webtop5 &> /dev/null
+        /usr/sbin/ns8-abort nethserver-roundcubemail &> /dev/null
+    fi
     /usr/sbin/ns8-abort "${app_id}" &> /dev/null
 elif [[ "$action" == "toggle-skip" ]]; then
     /usr/sbin/ns8-toggle-skip "${app_id}"

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -42,7 +42,8 @@
         loading.listApplications ||
           loading.connectionRead ||
           loading.migrationRead ||
-          loading.accountProviderInfo
+          loading.accountProviderInfo ||
+          loading.abortAction
       "
       class="spinner spinner-lg"
     ></div>
@@ -234,6 +235,7 @@
                 <button
                   @click="showStartMigrationModal(app)"
                   :disabled="isStartMigrationButtonDisabled(app)"
+                  v-if="!isMailChild(app)"
                   class="btn btn-default"
                 >
                   {{ $t("dashboard.start_migration") }}
@@ -243,6 +245,7 @@
                   :disabled="
                     loading.migrationUpdate || accountProviderMigrationStarted
                   "
+                  v-if="!isMailChild(app)"
                   class="btn btn-default"
                 >
                   {{
@@ -258,6 +261,7 @@
                 <button
                   @click="syncData(app)"
                   :disabled="loading.migrationUpdate || app.status == 'syncing'"
+                  v-if="!isMailChild(app)"
                   class="btn btn-primary"
                 >
                   {{ $t("dashboard.sync_data") }}
@@ -265,6 +269,7 @@
                 <button
                   @click="showFinishMigrationModal(app)"
                   :disabled="loading.migrationUpdate || app.status == 'syncing'"
+                  v-if="!isMailChild(app)"
                   class="btn btn-default"
                 >
                   {{ $t("dashboard.finish_migration") }}
@@ -272,13 +277,14 @@
                 <button
                   @click="showAbortModal(app)"
                   :disabled="loading.migrationUpdate || app.status == 'syncing'"
+                  v-if="!isMailChild(app)"
                   class="btn btn-default"
                 >
                   {{ $t("dashboard.abort") }}
                 </button>
               </template>
               <button
-                v-else-if="app.status == 'migrated'"
+                v-else-if="app.status == 'migrated' && !isMailChild(app)"
                 disabled
                 class="btn btn-default"
               >
@@ -888,6 +894,7 @@ export default {
         listApplications: false,
         accountProviderInfo: false,
         getClusterStatus: false,
+        abortAction: false
       },
       error: {
         connectionRead: "",
@@ -1412,6 +1419,7 @@ export default {
     abort(app) {
       const context = this;
       context.loading.migrationUpdate = true;
+      context.loading.abortAction = true;
       context.hideAbortModal();
       nethserver.exec(
         ["nethserver-ns8-migration/migration/update"],
@@ -1423,12 +1431,14 @@ export default {
         function(success) {
           context.migrationReadApps();
           context.loading.migrationUpdate = false;
+          context.loading.abortAction = false;
         },
         function(error) {
           const errorMessage = context.$i18n.t("dashboard.error_on_abort");
           console.error(errorMessage, error);
           context.error.migrationUpdate = errorMessage;
           context.loading.migrationUpdate = false;
+          context.loading.abortAction = false;
           context.migrationReadApps();
         },
         false
@@ -1566,6 +1576,10 @@ export default {
           ["nethserver-roundcubemail", "nethserver-webtop5"].includes(app.id))
       );
     },
+    isMailChild(app) {
+      return (this.emailApp &&
+          ["nethserver-roundcubemail", "nethserver-webtop5"].includes(app.id))
+    }
   },
 };
 </script>

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -333,7 +333,7 @@
                       [
                         'nethserver-roundcubemail',
                         'nethserver-webtop5',
-                      ].includes(app.id)
+                      ].includes(app.id) && app.status != 'skipped'
                     "
                     v-html="$t('dashboard.app_migrated_with_email')"
                   >


### PR DESCRIPTION
Reference: https://trello.com/c/OAQ51D2b/349-migtool-p-abort-does-not-work-with-webtop-and-roundcube

WebTop and Roundcube migration can't be skipped. If the user doesn't want them, it must delete the app on NS8 after migration.

Before starting the migration:
![Screenshot from 2023-04-27 14-36-42](https://user-images.githubusercontent.com/804596/234864917-c9d22849-5932-4709-a848-299161d9e1a6.png)

During migration:
![Screenshot from 2023-04-27 14-39-07](https://user-images.githubusercontent.com/804596/234864892-11dd0542-5f91-4140-9a6a-dcc28fbbd924.png)

Skipped migration:
![Screenshot from 2023-04-27 14-36-36](https://user-images.githubusercontent.com/804596/234864935-1901858c-0e49-41ba-934a-99f648111094.png)
