### PR TITLE
rsync on ns7 does not expand wildcard of --chown

### DIFF
--- a/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-ejabberd/migrate
+++ b/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-ejabberd/migrate
@@ -32,7 +32,7 @@ source bind.env
 : "${RSYNC_ENDPOINT:?}"
 export RSYNC_PASSWORD
 # Sync files: --owner --group --chown=9000:9000 are needed to map data for the ejabberd user
-rsync -tr --owner --group --chown=9000:9000 --delete  /var/lib/nethserver/ejabberd/upload/ "${RSYNC_ENDPOINT}"/data/volumes/upload/
+rsync -tr --owner --group --chown=9000:9000 -s --delete  /var/lib/nethserver/ejabberd/upload/ "${RSYNC_ENDPOINT}"/data/volumes/upload/
 
 # Sync ejabberd DB dump
 rm -vf /var/lib/nethserver/ejabberd/ejabberd.backup

--- a/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-mattermost/migrate
+++ b/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-mattermost/migrate
@@ -39,7 +39,7 @@ if [[ "${MIGRATE_ACTION}" == "finish" ]]; then
 fi
 
 # Sync files: --owner --group --chown=2000:2000 are needed to map data for the mattermost user
-rsync -tr --owner --group --chown=2000:2000 --delete  /var/lib/nethserver/mattermost/data/ "${RSYNC_ENDPOINT}"/data/volumes/mattermost-data/
+rsync -tr --owner --group --chown=2000:2000 -s --delete  /var/lib/nethserver/mattermost/data/ "${RSYNC_ENDPOINT}"/data/volumes/mattermost-data/
 
 # Create database dump
 su - postgres -c "scl enable rh-postgresql12 -- pg_dump --port 55434 mattermost > /var/lib/nethserver/mattermost/backup/dump.sql"

--- a/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-nextcloud/migrate
+++ b/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-nextcloud/migrate
@@ -39,7 +39,7 @@ if [[ "${MIGRATE_ACTION}" == "finish" ]]; then
 fi
 
 # Sync files: --owner --group --chown=82:82 are needed to map data for the www-data user
-rsync -tr --owner --group --chown=82:82 --delete --exclude=appdata\* --exclude=nextcloud.log /var/lib/nethserver/nextcloud/ "${RSYNC_ENDPOINT}"/data/volumes/nextcloud-app-data/data/
+rsync -tr --owner --group --chown=82:82 -s --delete --exclude=appdata\* --exclude=nextcloud.log /var/lib/nethserver/nextcloud/ "${RSYNC_ENDPOINT}"/data/volumes/nextcloud-app-data/data/
 
 # Create database dump
 mysqldump -S /run/rh-mariadb105-mariadb/nextcloud-mysql.sock nextcloud > /var/lib/nethserver/nextcloud/dump.sql


### PR DESCRIPTION
the migration path of some module is broken when we require to chown the data synchronized by rsync

the options `--owner --group --chown=2000:2000` are not honored anymore. It comes probably from the different version in alpine (3.2.7) and NS7 (3.1.2)
reading the documentation the `--chown` is a shortcut to `--usermap=*:foo --groupmap=*:bar`. It seems if we add the `s` (advised by the documentation), rsync does the correct chown for the migration

https://trello.com/c/3r7hU8Qm/379-fix-bad-ownership-with-rsync-migration
https://download.samba.org/pub/rsync/rsync.1#opt--chown