### PR TITLE
Optimize mailbox transfer

### DIFF
--- a/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-mail/migrate
+++ b/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-mail/migrate
@@ -72,7 +72,7 @@ fi
 # not work. Using the "catchall" range 1-1000 because "*" does not work
 
 # Send mailboxes
-rsync -i --archive --usermap=1-1000:100 --groupmap=1-1000:101 --delete /var/lib/nethserver/vmail/ "${RSYNC_ENDPOINT}"/data/volumes/dovecot-data/
+rsync -i --archive --usermap=1-1000:100 --groupmap=1-1000:101 --exclude lucene-indexes/ --delete /var/lib/nethserver/vmail/ "${RSYNC_ENDPOINT}"/data/volumes/dovecot-data/
 
 if [[ -f /var/lib/redis/rspamd/dump.rdb ]]; then
     # Fix rspamd-redis volume root dir perms


### PR DESCRIPTION
FTS Lucene is not available in NS8. As index dirs grow up to hundreds of MB, ignore them in mailbox dir transfer.

See https://nethserver.github.io/ns8-core/modules/updates/