### PR TITLE
Password validation, avoid pipe character

### DIFF
--- a/api/connection/validate
+++ b/api/connection/validate
@@ -61,6 +61,10 @@ if (user_p not in input_json) or (not input_json[user_p]):
 
 if (password_p not in input_json) or (not input_json[password_p]):
     invalid_attributes.append(invalid_attribute(password_p, "empty"))
+else:
+    password_verify = input_json[password_p]
+    if '|' in password_verify:
+        invalid_attributes.append(invalid_attribute(password_p, "not_allowed"))
 
 # tls verify
 

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -99,7 +99,8 @@
     "admin_username_empty": "Admin username is required",
     "admin_password_empty": "Admin password is required",
     "virtual_host_empty": "Virtual host is required",
-    "ad_ip_address_empty": "Active Directory IP address is required"
+    "ad_ip_address_empty": "Active Directory IP address is required",
+    "admin_password_not_allowed":"The `|` character is not allowed"
   },
   "docs": {},
   "are_you_sure": "Are you sure",


### PR DESCRIPTION
From https://trello.com/c/3d7gT1JO/448-migration-p0-e-smith-db-corrupt-with-pipe-char

The Pipe character inside a password field can break the e-smith database we need to validate that this character is not used. It is then required that the remote password does not contain `|` (pipe) characters