### PR TITLE
Disable getmail service and update configuration

### DIFF
--- a/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-mail-getmail/migrate
+++ b/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-mail-getmail/migrate
@@ -44,6 +44,15 @@ if [[ "${MIGRATE_ACTION}" != "finish" ]]; then
     exit 0
 fi
 
+# disabled getmail service
+# Read JSON data from file
+json_data=$(cat getmail.json)
+# Modify "status" field using jq
+modified_json=$(echo "$json_data" | jq '.[].props |= if .status == "enabled" then .status = "disabled" else . end')
+echo "$modified_json" |  /sbin/e-smith/db getmail setjson -
+# expand the getmail configuration with disabled status
+/usr/sbin/e-smith/signal-event nethserver-getmail-save
+
 # Obtain the Mail module UUID for configure-module:
 mail_instance_uuid=$(ns8-action --attach "module/${MAIL_INSTANCE_ID}" list-service-providers \
   "$(printf '{"service":"imap", "transport":"tcp", "filter":{"module_id":"%s"}}' "${MAIL_INSTANCE_ID}")" \

--- a/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-mail-getmail/migrate
+++ b/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-mail-getmail/migrate
@@ -45,11 +45,11 @@ if [[ "${MIGRATE_ACTION}" != "finish" ]]; then
 fi
 
 # disabled getmail service
-# Read JSON data from file
-json_data=$(cat getmail.json)
-# Modify "status" field using jq
-modified_json=$(echo "$json_data" | jq '.[].props |= if .status == "enabled" then .status = "disabled" else . end')
-echo "$modified_json" |  /sbin/e-smith/db getmail setjson -
+for key in $(/usr/sbin/e-smith/db getmail keys)
+do
+  /usr/sbin/e-smith/db getmail setprop "$key" status "disabled"
+done
+
 # expand the getmail configuration with disabled status
 /usr/sbin/e-smith/signal-event nethserver-getmail-save
 


### PR DESCRIPTION
This pull request disables the getmail service and updates the configuration. The getmail service is now disabled and the getmail configuration has been expanded with the disabled status. This change ensures that the getmail service is no longer active.

https://github.com/NethServer/dev/issues/6776