### PR TITLE
Relax account provider validator

### DIFF
--- a/api/migration/read
+++ b/api/migration/read
@@ -248,10 +248,13 @@ def check_user_domains():
                     return False
         return True
     else:
-        # if source account provider is external, NS8 must contain the same external provider
+        # if source account provider is external, NS8 must be already configured with the same domain
         for domain in obj['data']['output']['domains']:
-            if domain['location'] == 'external' and domain['base_dn'] == local_config['BaseDN']:
-                if (domain['schema'] == 'rfc2307' and local_config['isLdap']) or (domain['schema'] == 'ad' and local_config['isAd']):
+            if domain['base_dn'] == local_config['BaseDN'] \
+                and ( \
+                    (domain['schema'] == 'rfc2307' and local_config['isLdap']) \
+                    or (domain['schema'] == 'ad' and local_config['isAD']) \
+                ):
                     return True
         return False
 


### PR DESCRIPTION
Consider valid the scenario where NS8 is the external account provider of NS7. The domain match occurs in the BaseDN parameter of the NS7 and NS8 domains, no matter if internal or external to NS8.

Completes https://github.com/NethServer/dev/issues/6795