### PR TITLE
Fix condition to check for roundcubemail mariadb  directory existence

### DIFF
--- a/api/migration/read
+++ b/api/migration/read
@@ -169,7 +169,7 @@ def get_ejabberd_info():
 
 
 def get_webmail_info():
-    if os.path.isdir('/var/lib/mysql/roundcubemail'):
+    if os.path.isfile('/etc/e-smith/db/configuration/defaults/roundcubemail/type') and os.path.isdir('/var/lib/mysql/roundcubemail'):
         return {
             "id": "nethserver-roundcubemail",
             "name": "Webmail"

--- a/api/migration/read
+++ b/api/migration/read
@@ -169,7 +169,7 @@ def get_ejabberd_info():
 
 
 def get_webmail_info():
-    if os.path.isfile('/etc/e-smith/db/configuration/defaults/roundcubemail/type'):
+    if os.path.isdir('/var/lib/mysql/roundcubemail'):
         return {
             "id": "nethserver-roundcubemail",
             "name": "Webmail"


### PR DESCRIPTION
This pull request fixes the condition in the code that checks for the existence of the roundcubemail mariadb  directory. The previous condition was checking for a esmith file instead of a directory and we could make a mistake with nethserver-roundcubemail-next

This caused incorrect results in certain cases. The fix ensures that the correct check is performed

https://github.com/NethServer/dev/issues/6851