### PR TITLE
Fix migration script to handle roundcubemail directory existence

### DIFF
--- a/api/migration/update
+++ b/api/migration/update
@@ -77,7 +77,7 @@ elif [[ "$action" == "abort" ]]; then
         if [ -f '/etc/e-smith/db/configuration/defaults/webtop/type' ]; then
             /usr/sbin/ns8-abort nethserver-webtop5 &> /dev/null
         fi
-        if [ -f '/etc/e-smith/db/configuration/defaults/roundcubemail/type' ]; then
+        if [[ -f '/etc/e-smith/db/configuration/defaults/roundcubemail/type' && -d '/var/lib/mysql/roundcubemail' ]]; then
             /usr/sbin/ns8-abort nethserver-roundcubemail &> /dev/null
         fi
         if [ -f '/etc/e-smith/db/configuration/defaults/sogod/type' ]; then

--- a/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-mail/bind
+++ b/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-mail/bind
@@ -28,7 +28,7 @@ if [[ -f /etc/e-smith/db/configuration/defaults/webtop/type ]]; then
     ns8-bind-app nethserver-webtop5 "${WEBTOP_NODE_ID}" &
 fi
 
-if [[ -f /etc/e-smith/db/configuration/defaults/roundcubemail/type ]]; then
+if [[ -f /etc/e-smith/db/configuration/defaults/roundcubemail/type && -d '/var/lib/mysql/roundcubemail' ]]; then
     ns8-bind-app nethserver-roundcubemail "${ROUNDCUBE_NODE_ID}" &
 fi
 


### PR DESCRIPTION
This commit fixes the migration script to handle the existence of the roundcubemail directory. Previously, the script only checked for the existence of the roundcubemail configuration file, but now it also checks for the existence of the directory. This ensures that the migration process works correctly in all scenarios.

https://github.com/NethServer/dev/issues/6851