### PR TITLE
Fix migration detection of webtop virtualhost

### DIFF
--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -1609,8 +1609,10 @@ export default {
           let migrationConfig = {
             roundCubeVirtualHost: this.roundCubeVirtualHost,
           };
-
-          if (this.webtopVirtualHost) {
+          // if webtop virtualhost is already set, just uset it
+          if (this.webtopApp.config.props.VirtualHost) {
+            migrationConfig.webtopVirtualHost = this.webtopApp.config.props.VirtualHost;
+          } else if (this.webtopVirtualHost) {
             migrationConfig.webtopVirtualHost = this.webtopVirtualHost;
           }
 


### PR DESCRIPTION
This pull request fixes the migration detection of the webtop virtualhost. Previously, the migration would only set the webtop virtualhost if it was not already set. However, this caused an issue when the webtop virtualhost was already set in the Nextcloud app configuration. This pull request updates the migration to check if the webtop virtualhost is already set in the Nextcloud app configuration and uses it if available.


https://github.com/NethServer/dev/issues/6851