### PR TITLE
Fixes the validator in nethvoiceApp

### DIFF
--- a/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-nethvoice14/migrate
+++ b/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-nethvoice14/migrate
@@ -142,7 +142,7 @@ ns8-action --attach "module/${MODULE_INSTANCE_ID}" configure-module "$(
             "lets_encrypt": false,
             "nethcti_ui_host": $nethcti_ui_host,
             "nethvoice_host": $nethvoice_host,
-	    "phonebook_db_password": $phonebook_db_password,
+            "phonebook_db_password": $phonebook_db_password,
             "reports_international_prefix": $reports_international_prefix,
             "subscription_systemid": $subscription_systemid,
             "subscription_secret": $subscription_secret,

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -105,6 +105,7 @@
     "admin_username_empty": "Admin username is required",
     "admin_password_empty": "Admin password is required",
     "virtual_host_empty": "Virtual host is required",
+    "virtualhost_cannot_be_the_same": "Virtual host cannot be the same",
     "ad_ip_address_empty": "Active Directory IP address is required",
     "admin_password_not_allowed":"The `|` character is not allowed"
   },

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -1268,6 +1268,18 @@ export default {
             isValidationOk = false;
           }
         }
+
+        if (this.ctiVirtualHost && this.ctiVirtualHost === this.nethVoiceVirtualHost) {
+          this.error.ctiVirtualHost = this.$t(
+            "validation.virtualhost_cannot_be_the_same"
+          );
+
+          if (isValidationOk) {
+            this.$refs.ctiVirtualHost.focus();
+            isValidationOk = false;
+          }
+        }
+
       } else if (this.currentApp.id === "account-provider") {
         // account provider
 

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -1246,6 +1246,28 @@ export default {
         }
       } else if (this.currentApp.id === "nethserver-nethvoice14") {
         // nethvoice
+
+        if (this.nethvoiceApp && !this.nethVoiceVirtualHost) {
+          this.error.nethVoiceVirtualHost = this.$t(
+            "validation.virtual_host_empty"
+          );
+
+          if (isValidationOk) {
+            this.$refs.nethVoiceVirtualHost.focus();
+            isValidationOk = false;
+          }
+        }
+
+        if (this.nethvoiceApp && !this.ctiVirtualHost) {
+          this.error.ctiVirtualHost = this.$t(
+            "validation.virtual_host_empty"
+          );
+
+          if (isValidationOk) {
+            this.$refs.ctiVirtualHost.focus();
+            isValidationOk = false;
+          }
+        }
       } else if (this.currentApp.id === "account-provider") {
         // account provider
 
@@ -1271,28 +1293,6 @@ export default {
 
           if (isValidationOk) {
             this.$refs.roundcubeVirtualHost.focus();
-            isValidationOk = false;
-          }
-        }
-
-        if (this.nethvoiceApp && !this.nethVoiceVirtualHost) {
-          this.error.nethVoiceVirtualHost = this.$t(
-            "validation.virtual_host_empty"
-          );
-
-          if (isValidationOk) {
-            this.$refs.nethVoiceVirtualHost.focus();
-            isValidationOk = false;
-          }
-        }
-
-        if (this.nethvoiceApp && !this.ctiVirtualHost) {
-          this.error.ctiVirtualHost = this.$t(
-            "validation.virtual_host_empty"
-          );
-
-          if (isValidationOk) {
-            this.$refs.ctiVirtualHost.focus();
             isValidationOk = false;
           }
         }
@@ -1575,9 +1575,6 @@ export default {
             migrationConfig.roundcubeNode = this.roundcubeNode;
           }
 
-          if (this.nethvoiceApp) {
-            migrationConfig.nethvoiceNode = this.nethvoiceNode;
-          }
           if (this.sogoApp) {
             migrationConfig.sogoNode = this.sogoNode;
           }

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -1231,8 +1231,21 @@ export default {
       this.migrationUpdate(this.currentApp, "start");
       this.hideStartMigrationModal();
     },
+    cleanValidationError() {
+      // clean error messages for validation
+      this.error.virtualHost = "";
+      this.error.adIpAddress = "";
+      this.error.roundCubeVirtualHost = "";
+      this.error.nethVoiceVirtualHost = "";
+      this.error.ctiVirtualHost = "";
+      this.error.sogoVirtualHost = "";
+      this.error.webtopVirtualHost = "";
+      this.error.userDomains = "";
+    },
     validateFinishMigrationFromModal() {
       let isValidationOk = true;
+
+      this.cleanValidationError();
 
       if (this.currentApp.id === "nethserver-nextcloud") {
         // nextcloud


### PR DESCRIPTION
This pull request fixes the indentation in the `phonebook_db_password` field and also fixes the validation for the `nethvoice` and `cti` virtual hosts.


validate the virtualhost of cti and nethvoice 

![Capture d’écran du 2024-02-29 12-56-43](https://github.com/NethServer/nethserver-ns8-migration/assets/3164851/a27e6f25-a382-4c86-957d-56aa601c2adb)
![Capture d’écran du 2024-02-29 12-56-59](https://github.com/NethServer/nethserver-ns8-migration/assets/3164851/db697f16-33f8-4ae1-8371-f67e60ec7566)

![Capture d’écran du 2024-02-29 13-03-20](https://github.com/NethServer/nethserver-ns8-migration/assets/3164851/e6c91ba8-8952-479b-94d2-7960d4b95fa8)
![Capture d’écran du 2024-02-29 13-03-10](https://github.com/NethServer/nethserver-ns8-migration/assets/3164851/02d70e15-77c8-442f-8958-dd1cf1230694)
![Capture d’écran du 2024-02-29 12-57-43](https://github.com/NethServer/nethserver-ns8-migration/assets/3164851/18331854-6d83-4a1f-abab-fb2b7a780812)
![Capture d’écran du 2024-02-29 12-57-31](https://github.com/NethServer/nethserver-ns8-migration/assets/3164851/aafd5aaf-bc4e-4f3d-881c-d62c5e4c1743)



https://github.com/NethServer/dev/issues/6872