### PR TITLE
Fix condition to check for webtopApp virtual host

### DIFF
--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -1685,7 +1685,7 @@ export default {
             roundCubeVirtualHost: this.roundCubeVirtualHost,
           };
           // if webtop virtualhost is already set, just uset it
-          if (this.webtopApp.config.props.VirtualHost) {
+          if (this.webtopApp && this.webtopApp.config.props.VirtualHost) {
             migrationConfig.webtopVirtualHost = this.webtopApp.config.props.VirtualHost;
           } else if (this.webtopVirtualHost) {
             migrationConfig.webtopVirtualHost = this.webtopVirtualHost;


### PR DESCRIPTION
This pull request fixes the condition in the Dashboard.vue file that checks for the presence of the webtopApp virtual host. Previously, the condition was not properly checking for the existence of the webtopApp object, leading to potential errors. This fix ensures that the condition accurately checks for the webtopApp virtual host before proceeding with the migration configuration.

We cannot migrate the stack because I introduced a bug when webtop is not installed, we look after a json object not initialized 

https://github.com/NethServer/dev/issues/6876