### PR TITLE
Fix missing USER_DOMAIN with remote account providers

### DIFF
--- a/root/usr/sbin/ns8-join
+++ b/root/usr/sbin/ns8-join
@@ -212,9 +212,6 @@ if account_provider_config['isAD'] == '1':
         if add_external_domain_response['data']['exit_code'] != 0:
             print("Task add_external_domain has failed:", add_external_domain_response, file=sys.stderr)
             sys.exit(1)
-        with open('/var/lib/nethserver/nethserver-ns8-migration/environment', 'a') as fp:
-            fp.write(f"USER_DOMAIN={account_provider_domain}\n")
-
 elif account_provider_config['isLdap'] == '1' and '127.0.0.1' in account_provider_config['LdapURI']:
     # Configure OpenLDAP as account provider of an external user domain:
     account_provider_domain = "directory.nh"
@@ -235,5 +232,6 @@ elif account_provider_config['isLdap'] == '1' and '127.0.0.1' in account_provide
     if add_external_domain_response['data']['exit_code'] != 0:
         print("Task add_external_domain has failed:", add_external_domain_response, file=sys.stderr)
         sys.exit(1)
-    with open('/var/lib/nethserver/nethserver-ns8-migration/environment', 'a') as fp:
-        fp.write(f"USER_DOMAIN={account_provider_domain}\n")
+
+with open('/var/lib/nethserver/nethserver-ns8-migration/environment', 'a') as fp:
+    fp.write(f"USER_DOMAIN={account_provider_domain}\n")


### PR DESCRIPTION
The USER_DOMAIN variable must be set also with remote account providers, otherwise Mail migration fails.