### PR TITLE
Always migrate to Nextcloud version 27

### DIFF
--- a/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-nextcloud/bind.env
+++ b/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-nextcloud/bind.env
@@ -1,3 +1,3 @@
 # This file is included by ns8-bind-app
 MODULE_VOLUMES="nextcloud-app-data"
-MODULE_IMAGE_URL="ghcr.io/nethserver/nextcloud:1.1.6"
+MODULE_IMAGE_URL="ghcr.io/nethserver/nextcloud:1.1.7"


### PR DESCRIPTION
Set a fixed module version number: 1.1.7 (NC 27.1.11)

Refs https://github.com/orgs/NethServer/projects/8/views/1?filterQuery=nextcloud&pane=issue&itemId=61106037


https://github.com/NethServer/dev/issues/6964