### PR TITLE
Add SmartHost configuration to mail migration script

### DIFF
--- a/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-mail/migrate
+++ b/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-mail/migrate
@@ -113,4 +113,18 @@ rsync "${RSYNC_ENDPOINT}"/terminate
 # Wait until the import-module task has completed
 ns8-action --attach wait "${IMPORT_TASK_ID}"
 
+SmartHostStatus=$(/sbin/e-smith/config getprop postfix SmartHostStatus)
+if [[ "${SmartHostStatus}" == "enabled" ]]; then
+    # find the vpn ip address of the mail module
+    host=$(ns8-action --attach cluster get-smarthost | jq -r '.mail_server[] | select(.mail_id == "'$MAIL_INSTANCE_ID'") | .host')
+    ns8-action --attach cluster set-smarthost '{
+    "port": 25,
+    "host": "'${host}'",
+    "username": "",
+    "password": "",
+    "enabled": true,
+    "encrypt_smtp": "none",
+    "tls_verify": false}'
+fi
+
 migrate_deps


### PR DESCRIPTION
This pull request adds the SmartHost configuration to the mail migration script. The script now checks if the SmartHostStatus is enabled and sets the appropriate configuration for the SmartHost. This ensures that the mail module can communicate with the SmartHost properly during the migration process.

tested with ghcr.io/nethserver/core:2.8.0-dev.1 and ghcr.io/nethserver/mail:sdl-6895-import-NS7-credentials
NethServer/dev#6895

linked to https://github.com/NethServer/ns8-mail/pull/113