### PR TITLE
Add displayName attribute to users copied from gecos

### DIFF
--- a/root/usr/share/nethesis/nethserver-ns8-migration/apps/account-provider/ldap/migrate
+++ b/root/usr/share/nethesis/nethserver-ns8-migration/apps/account-provider/ldap/migrate
@@ -40,6 +40,11 @@ EOF
     /usr/sbin/slapcat -o ldif-wrap=no -n 2 -l dump-mdb0.ldif
 )
 
+# we need to add displayName attribute to the users copied from gecos
+# the displayName attribute is not present in the dump-mdb0.ldif
+# we need to add it manually
+sed -i '/^gecos: /{h;s/^gecos: \(.*\)/displayName: \1/;G}' dump-mdb0.ldif
+
 # Send import.env
 rsync -i import.env "${RSYNC_ENDPOINT:?}"/data/state/import.env
 

--- a/root/usr/share/nethesis/nethserver-ns8-migration/apps/account-provider/ldap/migrate
+++ b/root/usr/share/nethesis/nethserver-ns8-migration/apps/account-provider/ldap/migrate
@@ -40,10 +40,9 @@ EOF
     /usr/sbin/slapcat -o ldif-wrap=no -n 2 -l dump-mdb0.ldif
 )
 
-# we need to add displayName attribute to the users copied from gecos
-# the displayName attribute is not present in the dump-mdb0.ldif
-# we need to add it manually
-sed -i '/^gecos: /{h;s/^gecos: \(.*\)/displayName: \1/;G}' dump-mdb0.ldif
+# NS8 apps require a displayName attribute is set. Copy gecos attribute
+# value to displayName, assuming it is not already present.
+sed -i '/^gecos: / { h ; s/^gecos:/displayName:/ ; G }' dump-mdb0.ldif
 
 # Send import.env
 rsync -i import.env "${RSYNC_ENDPOINT:?}"/data/state/import.env


### PR DESCRIPTION
This pull request adds the `displayName` attribute to the users copied from `gecos` during the migration process. The `displayName` attribute was missing in the `dump-mdb0.ldif` file, so this PR includes a patch that adds it manually.

at the end the display name is populated after the migration

![image](https://github.com/NethServer/nethserver-ns8-migration/assets/3164851/9c932a2d-c86c-4c30-9aef-6bcc3cad2da9)


the sed command copy from gecos field the value and add it to the displayName field, at the end we add

```
+ displayName: john foo
gecos: john foo
```
https://github.com/NethServer/dev/issues/6930