### PR TITLE
Add error handling for failed external domain addition

### DIFF
--- a/api/connection/update
+++ b/api/connection/update
@@ -56,7 +56,6 @@ if [[ "$action" == "login" ]]; then
 elif [[ "$action" == "logout" ]]; then
     # disconnect from ns8 cluster
 
-    echo "=========== Leave cluster" $(date -R) >>/var/log/ns8-migration.log
     /usr/sbin/ns8-leave
     if [ $? -gt 0 ]; then
         error "EventFailed" "See /var/log/messages"

--- a/api/migration/update
+++ b/api/migration/update
@@ -82,7 +82,6 @@ elif [[ "$action" == "finish" ]]; then
     MIGRATE_ACTION="${action}" flock ${app_sdir}/syncing.lock "${app_idir}/migrate" &>>/var/log/ns8-migration.log
     touch ${app_sdir}/migrated
     if [[ "${app_id}" == "account-provider" ]]; then
-        echo "=========== Leave cluster" $(date -R) >>/var/log/ns8-migration.log
         /usr/sbin/ns8-leave
     fi
 elif [[ "$action" == "abort" ]]; then

--- a/root/usr/sbin/ns8-join
+++ b/root/usr/sbin/ns8-join
@@ -216,7 +216,9 @@ if account_provider_config['isAD'] == '1':
         call(api_endpoint, "remove-external-domain", payload['token'], {"domain": account_provider_domain}, False)
         add_external_domain_response = call(api_endpoint, "add-external-domain", payload['token'], add_external_domain_request, False)
         if add_external_domain_response['data']['exit_code'] != 0:
+            # we need to leave the cluster if the external domain cannot be added
             print("Task add_external_domain has failed:", add_external_domain_response, file=sys.stderr)
+            subprocess.run(['/usr/sbin/ns8-leave'])
             sys.exit(1)
 elif account_provider_config['isLdap'] == '1' and '127.0.0.1' in account_provider_config['LdapURI']:
     # Configure OpenLDAP as account provider of an external user domain:
@@ -237,7 +239,9 @@ elif account_provider_config['isLdap'] == '1' and '127.0.0.1' in account_provide
     call(api_endpoint, "remove-external-domain", payload['token'], {"domain": account_provider_domain}, False)
     add_external_domain_response = call(api_endpoint, "add-external-domain", payload['token'], add_external_domain_request, False)
     if add_external_domain_response['data']['exit_code'] != 0:
+        # we need to leave the cluster if the external domain cannot be added
         print("Task add_external_domain has failed:", add_external_domain_response, file=sys.stderr)
+        subprocess.run(['/usr/sbin/ns8-leave'])
         sys.exit(1)
 elif account_provider_config['isLdap'] == '1':
     # Remote LDAP account provider

--- a/root/usr/sbin/ns8-leave
+++ b/root/usr/sbin/ns8-leave
@@ -47,3 +47,5 @@ find /var/lib/nethserver/nethserver-ns8-migration -type f -not -name index.html 
 
 # signal event
 /sbin/e-smith/signal-event -j nethserver-ns8-migration-save
+# write log
+echo "=========== Leave cluster" $(date -R) >>/var/log/ns8-migration.log


### PR DESCRIPTION
This pull request adds error handling for failed external domain addition. If the external domain cannot be added, the cluster will be left using the `/usr/sbin/ns8-leave` command.

https://github.com/NethServer/dev/issues/6985


when the error comes

![image](https://github.com/user-attachments/assets/dae6efbf-19b9-41f5-8d59-34dd40912a72)

what you find in logs 
```
=========== Join cluster Fri, 02 Aug 2024 10:17:47 +0200
=========== Leave cluster Fri, 02 Aug 2024 10:17:56 +0200
{"steps":2,"pid":23770,"args":"","event":"nethserver-ns8-migration-save"}
{"step":1,"pid":23770,"action":"S05generic_template_expand","event":"nethserver-ns8-migration-save","state":"running"}
{"progress":"0.50","time":"0.05514","exit":0,"event":"nethserver-ns8-migration-save","state":"done","step":1,"pid":23770,"action":"S05generic_template_expand"}
{"step":2,"pid":23770,"action":"S90adjust-services","event":"nethserver-ns8-migration-save","state":"running"}
{"progress":"1.00","time":"0.1998","exit":0,"event":"nethserver-ns8-migration-save","state":"done","step":2,"pid":23770,"action":"S90adjust-services"}
{"pid":23770,"status":"success","event":"nethserver-ns8-migration-save"}
cluster/task/1e150f5c-6a12-4f40-a3eb-a6d061362a45
removed ‘/var/lib/nethserver/nethserver-ns8-migration/agent.env’
removed ‘/var/lib/nethserver/nethserver-ns8-migration/environment’
{"steps":2,"pid":24481,"args":"","event":"nethserver-ns8-migration-save"}
{"step":1,"pid":24481,"action":"S05generic_template_expand","event":"nethserver-ns8-migration-save","state":"running"}
{"progress":"0.50","time":"0.056436","exit":0,"event":"nethserver-ns8-migration-save","state":"done","step":1,"pid":24481,"action":"S05generic_template_expand"}
{"step":2,"pid":24481,"action":"S90adjust-services","event":"nethserver-ns8-migration-save","state":"running"}
{"progress":"1.00","time":"0.216974","exit":0,"event":"nethserver-ns8-migration-save","state":"done","step":2,"pid":24481,"action":"S90adjust-services"}
{"pid":24481,"status":"success","event":"nethserver-ns8-migration-save"}
Task add_external_domain has failed: {'code': 200, 'data': {'error': '<3>LDAPSocketOpenError: socket connection error while opening: [Errno 111] Connection refused\n', 'exit_code': 3, 'file': 'task/cluster/646a9993-fbb0-4a9b-b384-a5969c1dc8d4', 'output': [{'error': 'port_connection_error', 'field': 'port', 'parameter': 'port', 'value': 636}]}, 'message': 'success'}

```


if you cp and paste the command from UI

```
[root@NS2 ~]#  echo '{"action":"login","Host":"rocky9-pve.org","User":"admin","Password":"Nethesis,1234","TLSVerify":"disabled"}' | /usr/bin/setsid /usr/bin/sudo /usr/libexec/nethserver/api/nethserver-ns8-migration/connection/update | jq
{
  "steps": -1,
  "id": "1717508984",
  "type": "CommandFailed",
  "message": "{\"steps\":2,\"pid\":30951,\"args\":\"\",\"event\":\"nethserver-ns8-migration-save\"}\n{\"step\":1,\"pid\":30951,\"action\":\"S05generic_template_expand\",\"event\":\"nethserver-ns8-migration-save\",\"state\":\"running\"}\n{\"progress\":\"0.50\",\"time\":\"0.053631\",\"exit\":0,\"event\":\"nethserver-ns8-migration-save\",\"state\":\"done\",\"step\":1,\"pid\":30951,\"action\":\"S05generic_template_expand\"}\n{\"step\":2,\"pid\":30951,\"action\":\"S90adjust-services\",\"event\":\"nethserver-ns8-migration-save\",\"state\":\"running\"}\n{\"progress\":\"1.00\",\"time\":\"0.173759\",\"exit\":0,\"event\":\"nethserver-ns8-migration-save\",\"state\":\"done\",\"step\":2,\"pid\":30951,\"action\":\"S90adjust-services\"}\n{\"pid\":30951,\"status\":\"success\",\"event\":\"nethserver-ns8-migration-save\"}\ncluster/task/32035cfa-6b15-4529-b30c-308f53380113\nremoved ‘/var/lib/nethserver/nethserver-ns8-migration/agent.env’\nremoved ‘/var/lib/nethserver/nethserver-ns8-migration/environment’\n{\"steps\":2,\"pid\":31663,\"args\":\"\",\"event\":\"nethserver-ns8-migration-save\"}\n{\"step\":1,\"pid\":31663,\"action\":\"S05generic_template_expand\",\"event\":\"nethserver-ns8-migration-save\",\"state\":\"running\"}\n{\"progress\":\"0.50\",\"time\":\"0.05408\",\"exit\":0,\"event\":\"nethserver-ns8-migration-save\",\"state\":\"done\",\"step\":1,\"pid\":31663,\"action\":\"S05generic_template_expand\"}\n{\"step\":2,\"pid\":31663,\"action\":\"S90adjust-services\",\"event\":\"nethserver-ns8-migration-save\",\"state\":\"running\"}\n{\"progress\":\"1.00\",\"time\":\"0.208003\",\"exit\":0,\"event\":\"nethserver-ns8-migration-save\",\"state\":\"done\",\"step\":2,\"pid\":31663,\"action\":\"S90adjust-services\"}\n{\"pid\":31663,\"status\":\"success\",\"event\":\"nethserver-ns8-migration-save\"}\nTask add_external_domain has failed: {'code': 200, 'data': {'error': '<3>LDAPSocketOpenError: socket connection error while opening: [Errno 111] Connection refused\\n', 'exit_code': 3, 'file': 'task/cluster/14c6e3e1-2348-4455-af0d-a0b90769e113', 'output': [{'error': 'port_connection_error', 'field': 'port', 'parameter': 'port', 'value': 636}]}, 'message': 'success'}\n=========== Leave cluster Thu, 01 Aug 2024 15:50:11 +0200"
}
```
