### PR TITLE
Freeze Mattermost migration version

### DIFF
--- a/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-mattermost/bind.env
+++ b/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-mattermost/bind.env
@@ -1,3 +1,3 @@
 # This file is included by ns8-bind-app
 MODULE_VOLUMES="mattermost-data"
-MODULE_IMAGE_URL="ghcr.io/nethserver/mattermost:2.0.6"
+MODULE_IMAGE_URL="ghcr.io/nethserver/mattermost:2.0.7"


### PR DESCRIPTION
Mattermost 8 entered EOL on May 15, 2024. Freeze the application version used during migration, to avoid uncontrolled upgrades.

See https://docs.mattermost.com/about/unsupported-legacy-releases.html#release-v8-1-extended-support-release

https://github.com/NethServer/dev/issues/6997