### PR TITLE
Update MODULE_IMAGE_URL to use ghcr.io/nethserver/mattermost:2.0.7

### DIFF
--- a/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-mattermost/bind.env
+++ b/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-mattermost/bind.env
@@ -1,3 +1,3 @@
 # This file is included by ns8-bind-app
 MODULE_VOLUMES="mattermost-data"
-MODULE_IMAGE_URL="mattermost"
+MODULE_IMAGE_URL="ghcr.io/nethserver/mattermost:2.0.7"


### PR DESCRIPTION
This pull request updates the `MODULE_IMAGE_URL` in the `bind.env` file to use the `ghcr.io/nethserver/mattermost:2.0.7` image URL. This ensures that the correct image version is used for the Mattermost module.

https://github.com/NethServer/dev/issues/6997