### PR TITLE
Use ns7admin for migration

### DIFF
--- a/root/usr/sbin/ns8-join
+++ b/root/usr/sbin/ns8-join
@@ -155,9 +155,35 @@ except socket.gaierror:
     print("ns8-join: The cluster VPN endpoint name cannot be resolved. Please check DNS record and resolution of: %s" % (leader_epaddress), file=sys.stderr)
     sys.exit(2)
 
+# create the ns7admin user password
+ns7admin_pw = str(uuid.uuid4())
+ns7admin_pwh = hashlib.sha256(ns7admin_pw.encode('ASCII')).hexdigest()
+
+# Create the ns7admin user
+data_ns7admin = {
+        "grant": [
+            {
+                "on": "*",
+                "role": "owner"
+            }
+        ],
+        "password_hash": ns7admin_pwh,
+        "set": {
+            "display_name": "ns7admin"
+        },
+        "user": "ns7admin"
+    }
+
+add_user_response = call(api_endpoint, "add-user", payload['token'], data_ns7admin, False)
+if add_user_response['data']['exit_code'] != 0:
+    # we need to leave the cluster if the user ns7admin cannot be added
+    print("Task add_user ns7admin has failed:", add_user_response, file=sys.stderr)
+    subprocess.run(['/usr/sbin/ns8-leave'])
+    sys.exit(1)
+
 # Save config inside config db
 subprocess.run(["/sbin/e-smith/config", "setprop", "wg-quick@ns8", "Address", ret["ip_address"], "RemoteEndpoint", ret["leader_endpoint"], "RemoteKey", ret["leader_public_key"], "RemoteNetwork", ret['network'], "status", "enabled"], check=True)
-subprocess.run(["/sbin/e-smith/config", "setprop", "ns8", "Host", leader_epaddress, "User", args.username, "Password", args.password, "TLSVerify", "enabled" if args.tlsverify else "disabled", "LeaderIpAddress", ret['leader_ip_address']], check=True)
+subprocess.run(["/sbin/e-smith/config", "setprop", "ns8", "Host", leader_epaddress, "User", "ns7admin", "Password", ns7admin_pw, "TLSVerify", "enabled" if args.tlsverify else "disabled", "LeaderIpAddress", ret['leader_ip_address']], check=True)
 
 # Save agent environment
 with open('/var/lib/nethserver/nethserver-ns8-migration/agent.env', 'w') as fp:

--- a/root/usr/sbin/ns8-leave
+++ b/root/usr/sbin/ns8-leave
@@ -30,6 +30,7 @@ fi
 
 if [[ -n "${NODE_ID}" ]]; then
     ns8-action --detach cluster remove-node $(printf '{"node_id":%d}' "${NODE_ID}") || :
+    ns8-action --detach cluster remove-user '{"user": "ns7admin"}' || :
 fi
 
 # reset DB props


### PR DESCRIPTION
The ns8-join script has been updated to check for an existing user before joining and to create the ns7admin user and handle failure gracefully. The ns8-leave script has been updated to remove the ns7admin user when leaving the cluster. These changes ensure that the scripts function correctly and improve the overall stability of the system.

https://github.com/NethServer/dev/issues/6994