### PR TITLE
Enable SOGo after failed NS8 migration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -314,6 +314,10 @@ It is possible to manually re-enable the services with the following commands.
   rm -rf /etc/e-smith/templates-custom/etc/httpd/conf.d/zz_mattermost.conf
   signal-event nethserver-mattermost-update
 
+  # SOGo
+  config setprop sogod status enabled
+  signal-event nethserver-sogo-update
+
   # Nextcloud
   rm -rf /etc/e-smith/templates-custom/etc/httpd/conf.d/zz_nextcloud.conf
   rm -f /etc/e-smith/templates-custom/etc/httpd/conf.d/default-virtualhost.inc/40nextcloud


### PR DESCRIPTION
This pull request  documents how to enable back SOGo after a failed NS8 migration. 

The migration process was unsuccessful, and this commit document host to  SOGo is re-enabled by setting the `sogod` status to enabled and triggering the `nethserver-sogo-update` event.