### PR TITLE
Prevent stopping migration if account provider is not migrated

### DIFF
--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -979,7 +979,7 @@
           <form class="form-horizontal">
             <div class="modal-body">
               <!-- logout not allowed -->
-              <div v-if="someAppsHaveFinishedMigration">
+              <div v-if="migrationCannotBeStopped">
                 {{ $t("dashboard.disconnect_not_allowed_explanation") }}
               </div>
               <!-- logout allowed -->
@@ -992,7 +992,7 @@
               </div>
             </div>
             <div class="modal-footer">
-              <template v-if="someAppsHaveFinishedMigration">
+              <template v-if="migrationCannotBeStopped">
                 <button
                   type="button"
                   class="btn btn-primary"
@@ -1160,8 +1160,9 @@ export default {
       }
       return false;
     },
-    someAppsHaveFinishedMigration() {
-      return this.apps.some((app) => app.status === "migrated");
+    migrationCannotBeStopped() {
+      // migration cannot be stopped if account provider is not migrated itself (it is the last apps)
+      return this.apps.some((app) => app.id === "account-provider") && this.apps.some((app) => app.status === "migrated");
     },
     emailApp() {
       return this.apps.find((app) => app.id === "nethserver-mail");


### PR DESCRIPTION
This pull request updates the `Dashboard.vue` file to prevent to let the UI blocked when apps without account provider have been `migrated`.

Previously, the option to disconnect was not shown anymore  when an app has been seen  `migrated`, leading to potential issues. With this change, the option to disconnect will be shown 

if the account provider is not present 
or 
if apps have the status `migrated` and the account provider is present (remote or local)

https://github.com/NethServer/dev/issues/7005


tested cases 
- mattermost and/or nextcloud without account provider
- mattermost and nextcloud with an account provider
- mattermost and nextcloud with a remote account provider



The solution is not optimal, the user needs to click on the link `connect to a different cluster` but at least the UI is not blocked at the same point. The change to detect if we still have some modules to migrate without an account provider is maybe overhead for only two modules


once we have seen an app `migrated` with an account provider we still force the user to migrate all the applications to NS8, without account provider the sysadmin can leave when he wants