### PR TITLE
Fix ns8-leave script to remove ns7admin user with node ID as a string

### DIFF
--- a/root/usr/sbin/ns8-leave
+++ b/root/usr/sbin/ns8-leave
@@ -30,7 +30,7 @@ fi
 
 if [[ -n "${NODE_ID}" ]]; then
     ns8-action --detach cluster remove-node $(printf '{"node_id":%d}' "${NODE_ID}") || :
-    ns8-action --detach cluster remove-user $(printf '{"user":%d}' "ns7admin${NODE_ID}") || :
+    ns8-action --detach cluster remove-user $(printf '{"user":"%s"}' "ns7admin${NODE_ID}") || :
 fi
 
 # reset DB props


### PR DESCRIPTION
This pull request fixes an issue in the `ns8-leave` script where the `ns7admin` user was not being removed correctly when the node ID was passed as a digit. The patch updates the script to remove the user using the correct format for the node ID.

https://github.com/NethServer/dev/issues/6994