### PR TITLE
Add AdminMail to migration with default value

### DIFF
--- a/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-webtop5/migrate
+++ b/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-webtop5/migrate
@@ -103,12 +103,14 @@ while ! ns8-action --attach "module/${MODULE_INSTANCE_ID}" configure-module "$(
     --arg hostname "${WEBTOP_VHOST}" \
     --arg mail_domain "$(hostname -d)" \
     --arg mail_module "${MAIL_INSTANCE_ID}" \
+    --arg AdminMail "$(/sbin/e-smith/config getprop webtop-pecbridge AdminMail)" \
     '.props | {
         "hostname": $hostname,
         "mail_module": $mail_module,
         "mail_domain": $mail_domain,
         "timezone": .DefaultTimezone,
         "locale": .DefaultLocale,
+        "pecbridge_admin_mail": $AdminMail,
         "webapp": {
             "debug": (.Debug == "true"),
             "min_memory": (.MinMemory | tonumber),


### PR DESCRIPTION
This pull request adds the "AdminMail" field to the migration script for the "nethserver-webtop5" app. The field is set to a default value of an empty string.

https://github.com/NethServer/dev/issues/6984