### PR TITLE
Allow migration of account provider with "not_available" status

### DIFF
--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -1192,7 +1192,6 @@ export default {
           ![
             "account-provider",
             "nethserver-roundcubemail",
-            "nethserver-nethvoice14",
             "nethserver-sogo",
             "nethserver-webtop5",
             "nethserver-mail-getmail",

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -1188,6 +1188,7 @@ export default {
         (app) =>
           app.status !== "migrated" &&
           app.status !== "skipped" &&
+          app.status !== "not_available" &&
           ![
             "account-provider",
             "nethserver-roundcubemail",


### PR DESCRIPTION
This pull request enables 

- the migration of the account provider even if it has a "not_available" status. Previously, the migration was only allowed for certain statuses, but now it can be performed regardless of the status.
- It prevents migrating the account provider before the Netvoice app.


https://github.com/NethServer/dev/issues/7037