### PR TITLE
Fix case sensitive BaseDN comparison

### DIFF
--- a/api/migration/read
+++ b/api/migration/read
@@ -274,7 +274,7 @@ def check_user_domains():
     else:
         # if source account provider is external, NS8 must be already configured with the same domain
         for domain in obj['data']['output']['domains']:
-            if domain['base_dn'] == local_config['BaseDN'] \
+            if domain['base_dn'].lower() == local_config['BaseDN'].lower() \
                 and ( \
                     (domain['schema'] == 'rfc2307' and local_config['isLdap']) \
                     or (domain['schema'] == 'ad' and local_config['isAD']) \


### PR DESCRIPTION
The LDAP DN syntax is case insensitive. When the BaseDN values are compared we must ignore their case.

Refs https://github.com/NethServer/dev/issues/7111