### PR TITLE
Use a FQDN for LDAP domain and migration scripts instead of directory.nh

### DIFF
--- a/api/connection/read
+++ b/api/connection/read
@@ -23,16 +23,30 @@
 import sys
 import subprocess
 import simplejson
-
+import os
 
 def get_config():
+    props = {}
+
     # ns8 config
     bash_command = "/sbin/e-smith/config getjson ns8"
     process = subprocess.Popen(bash_command.split(), stdout=subprocess.PIPE)
     output, error = process.communicate()
     ns8_config = simplejson.loads(output)
+    props.update({"ns8": ns8_config})
 
-    return {"ns8": ns8_config}
+    # slapd config
+    if os.path.isfile('/etc/e-smith/db/configuration/defaults/slapd/type'):
+        bash_command = "/sbin/e-smith/config getjson slapd"
+        process = subprocess.Popen(bash_command.split(), stdout=subprocess.PIPE)
+        output, error = process.communicate()
+        slapd_config = simplejson.loads(output)
+        props.update({"slapd": slapd_config})
+    else :
+        props.update({"slapd": {}})
+
+    return props
+
 
 
 try:

--- a/api/connection/read
+++ b/api/connection/read
@@ -26,14 +26,12 @@ import simplejson
 import os
 
 def get_config():
-    props = {}
-
     # ns8 config
     bash_command = "/sbin/e-smith/config getjson ns8"
     process = subprocess.Popen(bash_command.split(), stdout=subprocess.PIPE)
     output, error = process.communicate()
     ns8_config = simplejson.loads(output)
-    props.update({"ns8": ns8_config})
+    props = {"ns8": ns8_config, "slapd": {"props":{"status": "disabled"}}}
 
     # slapd config
     if os.path.isfile('/etc/e-smith/db/configuration/defaults/slapd/type'):
@@ -41,13 +39,9 @@ def get_config():
         process = subprocess.Popen(bash_command.split(), stdout=subprocess.PIPE)
         output, error = process.communicate()
         slapd_config = simplejson.loads(output)
-        props.update({"slapd": slapd_config})
-    else :
-        props.update({"slapd": {}})
+        props["slapd"] = slapd_config
 
     return props
-
-
 
 try:
     config = get_config()

--- a/api/connection/update
+++ b/api/connection/update
@@ -30,6 +30,8 @@ host=$(echo $data | jq -r '.Host')
 user=$(echo $data | jq -r '.User')
 password=$(echo $data | jq -r '.Password')
 tls_verify=$(echo $data | jq -r '.TLSVerify')
+# user domain used to rename the directory.nh to another baseDN
+ldap_user_domain=$(echo $data | jq -r '.LdapUserDomain')
 
 if [[ "$action" == "login" ]]; then
     # execute ns8-join
@@ -38,9 +40,9 @@ if [[ "$action" == "login" ]]; then
     trap 'rm -f $tmp_output' EXIT
     echo "=========== Join cluster" $(date -R) >>/var/log/ns8-migration.log
     if [ "$tls_verify" = "disabled" ]; then
-        /usr/sbin/ns8-join --no-tlsverify "$host" "$user" "$password" &>"${tmp_output}"
+        /usr/sbin/ns8-join --no-tlsverify "$host" "$user" "$password" "$ldap_user_domain" &>"${tmp_output}"
     else
-        /usr/sbin/ns8-join "$host" "$user" "$password" &>"${tmp_output}"
+        /usr/sbin/ns8-join "$host" "$user" "$password" "$ldap_user_domain" &>"${tmp_output}"
     fi
 
     if [ "$?" -gt 0 ]; then

--- a/api/connection/validate
+++ b/api/connection/validate
@@ -22,10 +22,24 @@
 
 import sys
 import simplejson
+import re
 
 
 def invalid_attribute(parameter, error):
     return {"parameter": parameter, "error": error, "value": ""}
+
+def is_valid_fqdn(domain):
+    # Regex breakdown:
+    # - ^([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)+  # Domain labels
+    # - [a-zA-Z0-9]{2,63}$  # TLD with 2-63 characters
+    fqdn_pattern = r'^([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z0-9]{2,63}$'
+
+    # Check overall domain length
+    if not domain or len(domain) > 255:
+        return False
+
+    # Validate using regex
+    return re.match(fqdn_pattern, domain) is not None
 
 
 input_json = simplejson.load(sys.stdin)
@@ -36,11 +50,13 @@ host_p = 'Host'
 user_p = 'User'
 password_p = 'Password'
 tls_verify_p = 'TLSVerify'
+ldap_user_domain_p = 'LdapUserDomain'
 
 host = ''
 user = ''
 password = ''
 tls_verify = ''
+ldap_user_domain = ''
 
 # action
 
@@ -75,6 +91,16 @@ else:
 
     if tls_verify not in ['enabled', 'disabled']:
         invalid_attributes.append(invalid_attribute(tls_verify_p, "invalid"))
+
+# ldap user domain
+if (ldap_user_domain_p not in input_json) or (not input_json[ldap_user_domain_p]):
+    invalid_attributes.append(invalid_attribute(ldap_user_domain_p, "empty"))
+else:
+    ldap_user_domain = input_json[ldap_user_domain_p]
+
+    # check if the domain is a valid domain
+    if not is_valid_fqdn(ldap_user_domain):
+        invalid_attributes.append(invalid_attribute(ldap_user_domain_p, "invalid"))
 
 # output
 success = len(invalid_attributes) == 0

--- a/root/usr/sbin/ns8-join
+++ b/root/usr/sbin/ns8-join
@@ -75,15 +75,13 @@ def call(api_endpoint, action, token, data, tlsverify):
 
     return None
 
-# default value, must be unique per cluster
-ldap_user_domain = 'defaultLdap-' + subprocess.check_output(['/usr/bin/hostname', '-f'], encoding='utf-8').strip()
 
 parser = argparse.ArgumentParser()
 parser.add_argument('host')
 parser.add_argument('username', default="admin")
 parser.add_argument('password', default="Nethesis,1234")
 # user domain used to rename the directory.nh to another baseDN
-parser.add_argument('user_domain', default=ldap_user_domain)
+parser.add_argument('user_domain', default="")
 parser.add_argument('--no-tlsverify', dest='tlsverify', action='store_false', default=True)
 
 args = parser.parse_args()
@@ -253,6 +251,9 @@ if account_provider_config['isAD'] == '1':
             sys.exit(1)
 elif account_provider_config['isLdap'] == '1' and '127.0.0.1' in account_provider_config['LdapURI']:
     # Configure OpenLDAP as account provider of an external user domain: (retrieve the baseDN from the UI, directory.nh is obsoleted)
+    if not args.user_domain:
+        print("ns8-join: user_domain is required for OpenLDAP account provider", file=sys.stderr)
+        sys.exit(1)
     account_provider_domain = args.user_domain.lower()
     account_provider_external = ""
     add_external_domain_request = {

--- a/root/usr/sbin/ns8-join
+++ b/root/usr/sbin/ns8-join
@@ -75,11 +75,15 @@ def call(api_endpoint, action, token, data, tlsverify):
 
     return None
 
+# default value, must be unique per cluster
+ldap_user_domain = 'defaultLdap-' + subprocess.check_output(['/usr/bin/hostname', '-f'], encoding='utf-8').strip()
 
 parser = argparse.ArgumentParser()
 parser.add_argument('host')
 parser.add_argument('username', default="admin")
 parser.add_argument('password', default="Nethesis,1234")
+# user domain used to rename the directory.nh to another baseDN
+parser.add_argument('user_domain', default=ldap_user_domain)
 parser.add_argument('--no-tlsverify', dest='tlsverify', action='store_false', default=True)
 
 args = parser.parse_args()
@@ -248,8 +252,8 @@ if account_provider_config['isAD'] == '1':
             subprocess.run(['/usr/sbin/ns8-leave'])
             sys.exit(1)
 elif account_provider_config['isLdap'] == '1' and '127.0.0.1' in account_provider_config['LdapURI']:
-    # Configure OpenLDAP as account provider of an external user domain:
-    account_provider_domain = "directory.nh"
+    # Configure OpenLDAP as account provider of an external user domain: (retrieve the baseDN from the UI, directory.nh is obsoleted)
+    account_provider_domain = args.user_domain.lower()
     account_provider_external = ""
     add_external_domain_request = {
         "domain": account_provider_domain,

--- a/root/usr/share/nethesis/nethserver-ns8-migration/apps/account-provider/ldap/migrate
+++ b/root/usr/share/nethesis/nethserver-ns8-migration/apps/account-provider/ldap/migrate
@@ -53,7 +53,7 @@ sed -i '/^gecos: / { h ; s/^gecos:/displayName:/ ; G }' dump-mdb0.ldif
 # replace dc=directory,dc=nh by ldap_suffix
 sed -i "s/dc=directory,dc=nh/${ldap_suffix}/g" dump-mdb0.ldif
 # replace dc: directory by dc: host
-sed -i "s/dc: directory/dc: $host/" dump-mdb0.ldif 
+sed -i "s/^dc: directory/dc: $host/" dump-mdb0.ldif 
 
 # Send import.env
 rsync -i import.env "${RSYNC_ENDPOINT:?}"/data/state/import.env

--- a/root/usr/share/nethesis/nethserver-ns8-migration/apps/account-provider/ldap/migrate
+++ b/root/usr/share/nethesis/nethserver-ns8-migration/apps/account-provider/ldap/migrate
@@ -22,6 +22,13 @@
 
 set -e
 
+fqdn=${USER_DOMAIN:?}
+ldap_suffix=dc=$(echo "$fqdn" | sed 's/\./,dc=/g')
+# Extract the hostname (part before the first dot)
+host=${USER_DOMAIN%%.*}
+# Extract the domain (part after the first dot)
+domain=${USER_DOMAIN#*.}
+
 ldapservice_password=$(< /var/lib/nethserver/secrets/ldapservice)
 (
     umask 077
@@ -32,8 +39,8 @@ ldapservice_password=$(< /var/lib/nethserver/secrets/ldapservice)
     cat - >import.env <<EOF
 LDAP_SVCUSER=ldapservice
 LDAP_SVCPASS=${ldapservice_password}
-LDAP_DOMAIN=directory.nh
-LDAP_SUFFIX=dc=directory,dc=nh
+LDAP_DOMAIN=${fqdn}
+LDAP_SUFFIX=${ldap_suffix}
 EOF
 
     # Generate .ldif data dump
@@ -43,6 +50,10 @@ EOF
 # NS8 apps require a displayName attribute is set. Copy gecos attribute
 # value to displayName, assuming it is not already present.
 sed -i '/^gecos: / { h ; s/^gecos:/displayName:/ ; G }' dump-mdb0.ldif
+# replace dc=directory,dc=nh by ldap_suffix
+sed -i "s/dc=directory,dc=nh/${ldap_suffix}/g" dump-mdb0.ldif
+# replace dc: directory by dc: host
+sed -i "s/dc: directory/dc: $host/" dump-mdb0.ldif 
 
 # Send import.env
 rsync -i import.env "${RSYNC_ENDPOINT:?}"/data/state/import.env
@@ -58,7 +69,7 @@ if [[ "${MIGRATE_ACTION}" != "finish" ]]; then
 fi
 
 # Remove temporary external user domain
-ns8-action --attach cluster remove-external-domain "$(printf '{"domain":"%s"}' "directory.nh")" || :
+ns8-action --attach cluster remove-external-domain "$(printf '{"domain":"%s"}' $fqdn)" || :
 
 # Commit DC migration
 rsync -v "${RSYNC_ENDPOINT}"/terminate

--- a/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-ejabberd/migrate
+++ b/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-ejabberd/migrate
@@ -71,7 +71,7 @@ Host=$(/sbin/e-smith/config get DomainName)
 # Search for Samba or LDAP domain
 domain=$(/sbin/e-smith/config getprop sssd Realm | tr '[:upper:]' '[:lower:]')
 if [ -z "$domain" ]; then
-   domain="directory.nh"
+   domain=${USER_DOMAIN:?}
 fi
 
 # we find admin users from jabberadmins group

--- a/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-nextcloud/migrate
+++ b/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-nextcloud/migrate
@@ -122,7 +122,7 @@ ns8-action --attach wait "${IMPORT_TASK_ID}"
 # Search for Samba or LDAP domain
 domain=$(/sbin/e-smith/config getprop sssd Realm | tr '[:upper:]' '[:lower:]')
 if [ -z "$domain" ]; then
-   domain="directory.nh"
+   domain=${USER_DOMAIN:?}
 fi
 
 if [ -z "${host}" ]; then

--- a/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-sogo/migrate
+++ b/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-sogo/migrate
@@ -89,7 +89,7 @@ ns8-action --attach wait "${IMPORT_TASK_ID}"
 # Search for Samba or LDAP domain
 domain=$(/sbin/e-smith/config getprop sssd Realm | tr '[:upper:]' '[:lower:]')
 if [ -z "$domain" ]; then
-   domain="directory.nh"
+   domain=${USER_DOMAIN:?}
 fi
 
 # we find admin users

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -101,7 +101,7 @@
     "error_on_skip": "There was an error when changing the skip flag.",
     "app_migrated_with_ad": "This app is migrated together with Local Active Directory app",
     "enable_forge_sogo": "To successfully migrate SOGo, ensure NethForge repository is enabled under NS8 Settings",
-    "ldap_user_domain_description": "This machine uses an openLDAP account provider. The previous base DN directory.nh cannot be used any more, it must be renamed to a unique base DN like ldap.domain.tld",
+    "ldap_user_domain_description": "This machine uses a local OpenLDAP account provider. You must choose a new name for the domain, something like ldap.domain.tld. The name must be unique inside the NethServer 8 cluster",
     "ldap_user_domain": "LDAP user domain"
   },
   "validation": {

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -100,7 +100,9 @@
     "no_skip": "Enable migration",
     "error_on_skip": "There was an error when changing the skip flag.",
     "app_migrated_with_ad": "This app is migrated together with Local Active Directory app",
-    "enable_forge_sogo": "To successfully migrate SOGo, ensure NethForge repository is enabled under NS8 Settings"
+    "enable_forge_sogo": "To successfully migrate SOGo, ensure NethForge repository is enabled under NS8 Settings",
+    "ldap_user_domain_description": "This machine uses an openLDAP account provider. The previous base DN directory.nh cannot be used any more, it must be renamed to a unique base DN like ldap.domain.tld",
+    "ldap_user_domain": "LDAP user domain"
   },
   "validation": {
     "leader_node_empty": "Leader node is required",
@@ -109,7 +111,9 @@
     "virtual_host_empty": "Virtual host is required",
     "virtualhost_cannot_be_the_same": "Virtual host cannot be the same",
     "ad_ip_address_empty": "Active Directory IP address is required",
-    "admin_password_not_allowed":"The `|` character is not allowed"
+    "admin_password_not_allowed":"The `|` character is not allowed",
+    "ldap_user_domain_empty": "LDAP user domain is required",
+    "ldap_user_domain_invalid": "Invalid LDAP user domain"
   },
   "docs": {},
   "are_you_sure": "Are you sure",

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -1530,7 +1530,7 @@ export default {
         User: this.config.adminUsername,
         Password: this.config.adminPassword,
         TLSVerify: this.config.tlsVerify ? "enabled" : "disabled",
-        LdapUserDomain: this.config.ldapUserDomain
+        LdapUserDomain: this.isLdapEnabled ? this.config.ldapUserDomain : "ad.provider.is.used" // dummy value to validate, not used with ad
       };
 
       const context = this;


### PR DESCRIPTION
Update the LDAP configuration and migration scripts to utilize a fully qualified domain name (FQDN) given by the sysadmin,  instead of the hardcoded value directory.nh, enhancing flexibility and accuracy in domain handling.

https://github.com/NethServer/dev/issues/7103



![image](https://github.com/user-attachments/assets/83478676-dc1e-48bc-8b54-90f555b9e66d)
![image](https://github.com/user-attachments/assets/f1b8058a-2eec-4669-9724-d82140c39c44)
![image](https://github.com/user-attachments/assets/9321a798-c800-4a76-bdcc-4ef930e9691f)
![image](https://github.com/user-attachments/assets/348c9f92-b44d-4c1c-915b-22a9ac782e70)
![image](https://github.com/user-attachments/assets/e489d860-5e32-4363-a839-f3ef7075028f)
![image](https://github.com/user-attachments/assets/2cc6d52c-f80c-423c-a3b6-38ecfba8b49d)
![image](https://github.com/user-attachments/assets/d1aff652-eb2f-4c82-91cd-f81bdd578880)
