### PR TITLE
Migrate Nextcloud module image to version 1.1.9

### DIFF
--- a/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-nextcloud/bind.env
+++ b/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-nextcloud/bind.env
@@ -1,3 +1,3 @@
 # This file is included by ns8-bind-app
 MODULE_VOLUMES="nextcloud-app-data"
-MODULE_IMAGE_URL="ghcr.io/nethserver/nextcloud:1.1.7"
+MODULE_IMAGE_URL="ghcr.io/nethserver/nextcloud:1.1.9"


### PR DESCRIPTION
Update the Nextcloud module to use the latest image version 1.1.9.

https://github.com/NethServer/dev/issues/7103