### PR TITLE
Install nethvoice-proxy during nethvoice migration

### DIFF
--- a/root/usr/sbin/ns8-join
+++ b/root/usr/sbin/ns8-join
@@ -287,6 +287,15 @@ else:
     account_provider_domain = ""
     account_provider_external = ""
 
+# call list-modules to update the list of modules ans save it as a file
+list_modules_response = call(api_endpoint, "list-modules", payload['token'], None, False)
+if list_modules_response['data']['exit_code'] != 0:
+    print("Task list-modules has failed:", list_modules_response, file=sys.stderr)
+    subprocess.run(['/usr/sbin/ns8-leave']) # leave the cluster, we failed to connect to the external domain
+    sys.exit(1)
+with open('/var/lib/nethserver/nethserver-ns8-migration/list-modules.json', 'w') as fp:
+    json.dump(list_modules_response['data']['output'], fp)
+
 with open('/var/lib/nethserver/nethserver-ns8-migration/environment', 'a') as fp:
     fp.write(f"USER_DOMAIN={account_provider_domain}\n")
     fp.write(f"ACCOUNT_PROVIDER_EXTERNAL={account_provider_external}\n")

--- a/root/usr/sbin/ns8-join
+++ b/root/usr/sbin/ns8-join
@@ -287,15 +287,6 @@ else:
     account_provider_domain = ""
     account_provider_external = ""
 
-# call list-modules to update the list of modules ans save it as a file
-list_modules_response = call(api_endpoint, "list-modules", payload['token'], None, False)
-if list_modules_response['data']['exit_code'] != 0:
-    print("Task list-modules has failed:", list_modules_response, file=sys.stderr)
-    subprocess.run(['/usr/sbin/ns8-leave']) # leave the cluster, we failed to connect to the external domain
-    sys.exit(1)
-with open('/var/lib/nethserver/nethserver-ns8-migration/list-modules.json', 'w') as fp:
-    json.dump(list_modules_response['data']['output'], fp)
-
 with open('/var/lib/nethserver/nethserver-ns8-migration/environment', 'a') as fp:
     fp.write(f"USER_DOMAIN={account_provider_domain}\n")
     fp.write(f"ACCOUNT_PROVIDER_EXTERNAL={account_provider_external}\n")

--- a/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-nethvoice14/bind
+++ b/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-nethvoice14/bind
@@ -22,17 +22,8 @@
 
 set -e
 
-# read list-modules.json
-JSON_FILE="/var/lib/nethserver/nethserver-ns8-migration/list-modules.json"
-
-# Check if nethvoice-proxy > 0 on the node
-is_installed=$(jq -r --argjson node_id "$MODULE_NODE_ID" '
-  .[] | select(.id == "nethvoice-proxy") | .install_destinations[] | select(.node_id == $node_id) | .instances > 0
-' "$JSON_FILE")
-
-# if not installed in the node, install first nethvoice-proxy
-if [[ "$is_installed" == "false" ]]; then
-     ns8-action --attach cluster add-module "$(printf '{"image": "nethvoice-proxy", "node": %d}' "${MODULE_NODE_ID}")"
+if ns8-action --attach cluster list-modules | jq -e --arg node_id "${MODULE_NODE_ID:?missing node ID} " '.[] | select(.id == "nethvoice-proxy") | .install_destinations[] | select(.node_id == $node_id and .eligible == true)' > /dev/null; then
+    ns8-action --attach cluster add-module "$(printf '{"image": "nethvoice-proxy", "node": %d}' "${MODULE_NODE_ID}")"
 fi
 
 ns8-bind-app nethserver-nethvoice14

--- a/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-nethvoice14/bind
+++ b/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-nethvoice14/bind
@@ -22,7 +22,7 @@
 
 set -e
 
-if ns8-action --attach cluster list-modules | jq -e --arg node_id "${MODULE_NODE_ID:?missing node ID} " '.[] | select(.id == "nethvoice-proxy") | .install_destinations[] | select(.node_id == $node_id and .eligible == true)' > /dev/null; then
+if ns8-action --attach cluster list-modules | jq -e --argjson node_id "${MODULE_NODE_ID:?missing node ID} " '.[] | select(.id == "nethvoice-proxy") | .install_destinations[] | select(.node_id == $node_id and .eligible == true)' > /dev/null; then
     ns8-action --attach cluster add-module "$(printf '{"image": "nethvoice-proxy", "node": %d}' "${MODULE_NODE_ID}")"
 fi
 

--- a/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-nethvoice14/bind
+++ b/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-nethvoice14/bind
@@ -22,4 +22,17 @@
 
 set -e
 
+# read list-modules.json
+JSON_FILE="/var/lib/nethserver/nethserver-ns8-migration/list-modules.json"
+
+# Check if nethvoice-proxy > 0 on the node
+is_installed=$(jq -r --argjson node_id "$MODULE_NODE_ID" '
+  .[] | select(.id == "nethvoice-proxy") | .install_destinations[] | select(.node_id == $node_id) | .instances > 0
+' "$JSON_FILE")
+
+# if not installed in the node, install first nethvoice-proxy
+if [[ "$is_installed" == "false" ]]; then
+     ns8-action --attach cluster add-module "$(printf '{"image": "nethvoice-proxy", "node": %d}' "${MODULE_NODE_ID}")"
+fi
+
 ns8-bind-app nethserver-nethvoice14


### PR DESCRIPTION
Test if the nethvoice proxy is installed on the node where we migrate nethserver-nethvoice14

Install on the ns8 node only if missing 

- we trigger list-modules action each time the bind for nethvoice is triggered
- we check, can we install  on the node where we migrate nethvoice
- if true we install the proxy



https://github.com/NethServer/dev/issues/7221