### PR TITLE
Lock UI during app installation/bind

### DIFF
--- a/api/migration/update
+++ b/api/migration/update
@@ -73,7 +73,8 @@ fi
 echo "----------- ${action} ${app_id}" $(date -R) >>/var/log/ns8-migration.log
 
 if [ "$action" == "start" ]; then
-    "${app_idir}/bind" &>>/var/log/ns8-migration.log
+    mkdir -vp "${app_sdir}"
+    flock "${app_sdir}/syncing.lock" "${app_idir}/bind" &>>/var/log/ns8-migration.log
 elif [[ "$action" == "sync" ]]; then
     run_check_import "${app_id}"
     MIGRATE_ACTION="${action}" flock ${app_sdir}/syncing.lock "${app_idir}/migrate" &>>/var/log/ns8-migration.log


### PR DESCRIPTION
If I hit browser's F5 key just after pressing App's "Start Migration" the UI looses the state of the remote NS8 task.

This PR creates --after the `Start migration`  button is pressed-- the same lock file used by the `Sync data` button.

Refs https://github.com/NethServer/dev/issues/7239