### PR TITLE
Add AD provider installation checks for cluster nodes and dashboard selection

### DIFF
--- a/api/migration/read
+++ b/api/migration/read
@@ -242,23 +242,19 @@ def list_apps():
     return apps
 
 def get_cluster_status():
-    bash_command = "/usr/sbin/ns8-action cluster get-cluster-status null"
-    process = subprocess.Popen(bash_command.split(), stdout=subprocess.PIPE)
-    output, error = process.communicate()
-
-    output = json.loads(output.decode('utf-8'))
+    bash_command = ["/usr/sbin/ns8-action", "cluster", "get-cluster-status", "null"]
+    process = subprocess.check_output(bash_command)
+    output = json.loads(process.decode('utf-8'))
 
     # list all modules
     command = ["/usr/sbin/ns8-action", "cluster", "list-modules", "null"]
-    process = subprocess.Popen(command, stdout=subprocess.PIPE)
-    modules_output, error = process.communicate()
-    modules = json.loads(modules_output)
+    process = subprocess.check_output(command)
+    modules = json.loads(process.decode('utf8'))
 
     # list all AD providers
     command = ["/usr/sbin/ns8-action", "cluster", "list-user-domains", "null"]
-    process = subprocess.Popen(command, stdout=subprocess.PIPE)
-    domains_output, error = process.communicate()
-    domains = json.loads(domains_output)
+    process = subprocess.check_output(command)
+    domains= json.loads(process.decode('utf8'))
 
     # iterate over all nodes and check if mail and ejabberd are installed
     for node in output["data"]["output"]["nodes"]:

--- a/api/migration/read
+++ b/api/migration/read
@@ -254,7 +254,7 @@ def get_cluster_status():
     # list all AD providers
     command = ["/usr/sbin/ns8-action", "cluster", "list-user-domains", "null"]
     process = subprocess.check_output(command)
-    domains= json.loads(process.decode('utf8'))
+    domains = json.loads(process.decode('utf8'))
 
     # iterate over all nodes and check if mail and ejabberd are installed
     for node in output["data"]["output"]["nodes"]:

--- a/api/migration/read
+++ b/api/migration/read
@@ -254,11 +254,18 @@ def get_cluster_status():
     modules_output, error = process.communicate()
     modules = json.loads(modules_output)
 
+    # list all AD providers
+    command = ["/usr/sbin/ns8-action", "cluster", "list-user-domains", "null"]
+    process = subprocess.Popen(command, stdout=subprocess.PIPE)
+    domains_output, error = process.communicate()
+    domains = json.loads(domains_output)
+
     # iterate over all nodes and check if mail and ejabberd are installed
     for node in output["data"]["output"]["nodes"]:
         node_id = node["id"]
         node["mail_installed"] = False
         node["ejabberd_installed"] = False
+        node["adProvider_installed"] = False
         for module in modules['data']['output']:
             if module.get("id") == "mail":
                 for destination in module.get("install_destinations", []):
@@ -268,6 +275,14 @@ def get_cluster_status():
                 for destination in module.get("install_destinations", []):
                     if destination["node_id"] == node_id and not destination["eligible"]:
                         node["ejabberd_installed"] = True
+        for domain in domains['data']['output']['domains']:
+            if domain["schema"] == "ad":
+                providers = domain["providers"]
+                for provider in providers:
+                    provider_node_id = provider["node"]
+                    if provider_node_id == node_id:
+                        node["adProvider_installed"] = True
+                        break
 
     return simplejson.loads(json.dumps(output))
 

--- a/root/usr/sbin/ns8-join
+++ b/root/usr/sbin/ns8-join
@@ -117,6 +117,44 @@ payload = json.loads(resp.read())
 account_provider_json = subprocess.check_output(['/usr/sbin/account-provider-test', 'dump'], encoding='utf-8')
 account_provider_config = json.loads(account_provider_json)
 
+# Test if the cluster has a room for an active directory (needs at least one node free)
+# only if the account provider is AD and local
+if account_provider_config['isAD'] == '1':
+    nsdc_ip_address = ""
+    try:
+        # If the account provider is AD, assume it is local and try to get nsdc IP address, otherwise skip.
+        nsdc_props_json = subprocess.check_output(['/sbin/e-smith/config', 'printjson', 'nsdc'], encoding='utf-8')
+        nsdc_ip_address = json.loads(nsdc_props_json)['props']['IpAddress']
+        # Get the cluster status
+        cluster = call(api_endpoint, "get-cluster-status", payload['token'], {}, False)
+        # List all AD providers
+        domains  = call(api_endpoint, "list-user-domains", payload['token'], {}, False)
+        # Initialize the flag
+        all_installed = True
+        # Parse all nodes
+        for node in cluster["data"]["output"]["nodes"]:
+            node_id = node["id"]
+            node["adProvider_installed"] = False  # Default to False
+            # Check each domain for AD providers
+            for domain in domains['data']['output']['domains']:
+                if domain["schema"] == "ad":
+                    for provider in domain["providers"]:
+                        if provider["node"] == node_id:
+                            node["adProvider_installed"] = True  # Mark as installed
+
+            # no AD installed set the flag
+            if not node["adProvider_installed"]:
+                all_installed = False
+        # If all nodes have providers
+        if all_installed:
+            print("no_available_node_for_samba_provider", file=sys.stderr)
+            sys.exit(1)
+    except json.JSONDecodeError:
+        pass # Ignore missing nsdc/IpAddress prop
+    except Exception as e:
+        print("Error:", e, file=sys.stderr)
+        sys.exit(1)
+
 # Generate a new Wireguard key. If add-node succeedes, but VPN connection
 # fails, we must not reuse the same key to avoid conflicts.
 tmpmask = os.umask(0o077)
@@ -211,12 +249,8 @@ api_endpoint = f"http://{ret['leader_ip_address']}:9311"
 if account_provider_config['isAD'] == '1':
     sssd_props_json = subprocess.check_output(['/sbin/e-smith/config', 'printjson', 'sssd'], encoding='utf-8')
     account_provider_domain = json.loads(sssd_props_json)['props']['Realm'].lower()
-    try:
-        # If the account provider is AD, assume it is local and try to get nsdc IP address, otherwise skip.
-        nsdc_props_json = subprocess.check_output(['/sbin/e-smith/config', 'printjson', 'nsdc'], encoding='utf-8')
-        nsdc_ip_address = json.loads(nsdc_props_json)['props']['IpAddress']
-    except:
-        pass # Ignore missing nsdc/IpAddress prop
+    if nsdc_ip_address == "":
+        # Ignore missing nsdc/IpAddress prop
         account_provider_external = "1"
     else:
         account_provider_external = ""

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -110,9 +110,9 @@
     "error_certificate_verify_failed": "Certificate verification failed. You can deselect 'TLS validation' to skip this check, if necessary",
     "error_no_route_to_host": "Connection to NS8 cluster failed. Please check the IP address or the fully qualified domain name",
     "error_port_connection_error": "NS8 cannot connect to the NS7 LDAP service. Ensure that LDAP ports (e.g. 389, 636 of slapd service) are open and accessible from the green zone.",
-    "already_installed_on_this_node": "Already installed on this node",
-    "no_available_node_for_samba_provider": "No available node for Samba Active Directory provider, you have to add a new node to migrate the Samba Active Directory provider",
-    "read_cluster_status": "Read cluster status"
+    "already_installed_on_this_node": "App instance is already installed",
+    "no_available_node_for_samba_provider": "Local Active Directory migration cannot proceed because the NS8 cluster has no eligible nodes. Add a new node to enable the migration.",
+    "read_cluster_status": "Refresh cluster status"
   },
   "validation": {
     "leader_node_empty": "Leader node is required",

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -110,7 +110,9 @@
     "error_certificate_verify_failed": "Certificate verification failed. You can deselect 'TLS validation' to skip this check, if necessary",
     "error_no_route_to_host": "Connection to NS8 cluster failed. Please check the IP address or the fully qualified domain name",
     "error_port_connection_error": "NS8 cannot connect to the NS7 LDAP service. Ensure that LDAP ports (e.g. 389, 636 of slapd service) are open and accessible from the green zone.",
-    "already_installed_on_this_node": "Already installed on this node"
+    "already_installed_on_this_node": "Already installed on this node",
+    "no_available_node_for_samba_provider": "No available node for Samba Active Directory provider, you have to add a new node to migrate the Samba Active Directory provider",
+    "read_cluster_status": "Read cluster status"
   },
   "validation": {
     "leader_node_empty": "Leader node is required",

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -222,7 +222,7 @@
         </div>
         <!-- account provider samba ad node limit banner-->
         <div v-if="!isAvailableNodeForSambaProvider && config.isConnected">
-          <div class="alert alert-info alert-dismissable">
+          <div class="alert alert-danger">
             <button
               @click="connectionRead()"
               :disabled="loading.migrationUpdate"
@@ -230,7 +230,7 @@
             >
               {{ $t("dashboard.read_cluster_status") }}
             </button>
-            <span class="pficon pficon-info"></span>
+            <span class="pficon pficon-error-circle-o"></span>
             {{ $t("dashboard.no_available_node_for_samba_provider") }}
           </div>
         </div>

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -1778,6 +1778,10 @@ export default {
           const portConnectionErrorMatch = streamMessage.match(
             /port_connection_error/i
           );
+          // check no_available_node_for_samba_provider
+          const noAvailableNodeForSambaProviderMatch = streamMessage.match(
+            /no_available_node_for_samba_provider/i
+          );
           if (domainExistMatch && context.isLdapEnabled) {
             context.error.rawConnectionUpdateMessage = context.$i18n.t(
               "dashboard.ldap_error_domain_exists", {
@@ -1790,6 +1794,10 @@ export default {
               "dashboard.ad_error_domain_exists", {
                 domain: domainValue
               }
+            );
+          } else if (noAvailableNodeForSambaProviderMatch && !context.isLdapEnabled) {
+            context.error.rawConnectionUpdateMessage = context.$i18n.t(
+              "dashboard.no_available_node_for_samba_provider"
             );
           } else if (unauthorizedMatch) {
             context.error.rawConnectionUpdateMessage = context.$i18n.t(

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -44,7 +44,8 @@
         loading.connectionRead ||
         loading.migrationRead ||
         loading.accountProviderInfo ||
-        loading.abortAction
+        loading.abortAction ||
+        loading.getClusterStatus
       "
       class="spinner spinner-lg"
     ></div>
@@ -219,7 +220,20 @@
             </a>
           </span>
         </div>
-
+        <!-- account provider samba ad node limit banner-->
+        <div v-if="!isAvailableNodeForSambaProvider && config.isConnected">
+          <div class="alert alert-info alert-dismissable">
+            <button
+              @click="connectionRead()"
+              :disabled="loading.migrationUpdate"
+              class="btn btn-default cluster-status"
+            >
+              {{ $t("dashboard.read_cluster_status") }}
+            </button>
+            <span class="pficon pficon-info"></span>
+            {{ $t("dashboard.no_available_node_for_samba_provider") }}
+          </div>
+        </div>
         <div
           v-if="accountProviderMigrationStarted"
           class="alert alert-info alert-dismissable"
@@ -250,7 +264,9 @@
                 "
                 @click="showStartMigrationModal(app)"
                 :disabled="
-                  loading.migrationUpdate || !canStartAccountProviderMigration
+                  loading.migrationUpdate ||
+                  !canStartAccountProviderMigration ||
+                  !isAvailableNodeForSambaProvider
                 "
                 class="btn btn-default"
               >
@@ -279,7 +295,10 @@
               >
                 <button
                   @click="showStartMigrationModal(app)"
-                  :disabled="isStartMigrationButtonDisabled(app)"
+                  :disabled="
+                    isStartMigrationButtonDisabled(app) ||
+                    !isAvailableNodeForSambaProvider
+                  "
                   v-if="!isMailChild(app) && !isAdChild(app)"
                   class="btn btn-default"
                 >
@@ -447,15 +466,21 @@
                   <span class="pficon pficon-error-circle-o"></span>
                   {{ error.getClusterStatus }}
                 </div>
-                <template v-if="currentApp.id === 'account-provider'">
-                  <div class="mg-bottom-20">
-                    {{
-                      $t(
-                        "dashboard.start_account_provider_migration_explanation",
-                        { leaderNode: config.leaderNode }
-                      )
-                    }}
-                  </div>
+                <template v-if="!loading.getClusterStatus">
+                  <template
+                    v-if="
+                      currentApp.id === 'account-provider' && !isSaveDisabled
+                    "
+                  >
+                    <div class="mg-bottom-20">
+                      {{
+                        $t(
+                          "dashboard.start_account_provider_migration_explanation",
+                          { leaderNode: config.leaderNode }
+                        )
+                      }}
+                    </div>
+                  </template>
                 </template>
                 <template v-else>
                   <div v-if="!loading.getClusterStatus" class="mg-bottom-20">
@@ -667,6 +692,40 @@
                             :disabled="!node.online || node.ejabberd_installed"
                           >
                             <span v-if="node.ejabberd_installed"
+                              >{{ getNodeLabel(node) }}
+                              {{
+                                $t("dashboard.already_installed_on_this_node")
+                              }}</span
+                            >
+                            <span v-else>{{ getNodeLabel(node) }}</span>
+                          </option>
+                        </select>
+                      </div>
+                    </div>
+                  </template> 
+                  <template v-else-if="currentApp.provider === 'ad'">
+                    <!-- node selection for AD apps -->
+                    <div class="form-group">
+                      <label class="col-sm-5 control-label" for="adprovider-node">
+                        {{
+                          $t("dashboard.destination_node", {
+                            app: currentApp.name
+                          })
+                        }}
+                      </label>
+                      <div class="col-sm-6">
+                        <select
+                          v-model="appNode"
+                          class="combobox form-control"
+                          id="adprovider-node"
+                        >
+                          <option
+                            v-for="node in clusterNodes"
+                            v-bind:key="node.id"
+                            :value="node.id"
+                            :disabled="!node.online || node.adProvider_installed"
+                          >
+                            <span v-if="node.adProvider_installed"
                               >{{ getNodeLabel(node) }}
                               {{
                                 $t("dashboard.already_installed_on_this_node")
@@ -1261,8 +1320,27 @@ export default {
           (node) => node.id === this.appNode
         );
         return selectedNode ? selectedNode.ejabberd_installed : false;
+      } else if (this.currentApp && this.currentApp.provider === "ad") {
+        const selectedNode = this.clusterNodes.find(
+          (node) => node.id === this.appNode
+        );
+        return selectedNode ? selectedNode.adProvider_installed : false;
       }
       return false;
+    },
+    isAvailableNodeForSambaProvider() {
+      // check if there is a node available for samba provider, return true if there is
+      if (
+        this.accountProviderConfig.type === "ad" &&
+        this.accountProviderConfig.location === "local"
+      ) {
+        return this.clusterNodes.some(
+          (node) => node.online && !node.adProvider_installed
+        );
+      } else {
+        // if account provider is not ad or is remote, return true
+        return true;
+      }
     },
     accountProviderApp() {
       return this.apps.find((app) => app.id === "account-provider");
@@ -1596,6 +1674,7 @@ export default {
       this.loading.connectionRead = false;
       this.isLdapEnabled = slapd.status === "enabled";
       if (this.config.isConnected) {
+        this.migrationReadClusterStatus();
         this.listApplications();
       } else {
         this.$nextTick(() => {
@@ -2180,6 +2259,10 @@ export default {
   justify-content: flex-end;
 }
 
+.cluster-status {
+  margin-right: 0px !important;
+  float: right;
+}
 .node-spinner {
   margin-left: 20px;
 }


### PR DESCRIPTION
Implement checks for Active Directory provider installation on cluster nodes and enhance the dashboard to allow node selection for AD applications based on installation status.

https://github.com/NethServer/dev/issues/7226

if we have no node available, now we cannot login anymore

![image](https://github.com/user-attachments/assets/c2293455-1392-44ec-b818-05843278f661)


if we succeed to login but someone starts to install a AD on the NS8 after you succeed to login
![image](https://github.com/user-attachments/assets/3a25245b-d65e-4286-aabc-8556925099e0)

when we have a node available

![image](https://github.com/user-attachments/assets/8a9738d7-8838-4b82-a20d-32a4bd828613)

in case of a cluster with only one node 

![image](https://github.com/user-attachments/assets/57a8922e-478d-4066-8b41-4c3802dc8a69)

https://github.com/user-attachments/assets/3eb4966f-4f1c-4176-92be-9157209f17bc


https://github.com/user-attachments/assets/b0480ae0-970a-4af1-aa64-0cbd89f46a93





for now there is no check about if dnsmasq is installed with dns server enabled