### PR TITLE
feat(ns8-join): declare worker version

### DIFF
--- a/root/usr/sbin/ns8-join
+++ b/root/usr/sbin/ns8-join
@@ -210,6 +210,7 @@ node_pwh = hashlib.sha256(node_pw.encode('ASCII')).hexdigest()
 
 # Prepare arguments for add-node
 data = {
+    "core_version": "0.0.0-ns7", # Semver value, required by Core 3.6+
     "node_pwh": node_pwh,
     "public_key": pub_key,
     "endpoint": "",


### PR DESCRIPTION
With Core 3.6+ the add-node action requires that a worker node declares its version for a sanity check.

Refs NethServer/dev#7376