### PR TITLE
Fix abort action requiring sudo rights for migration log

### DIFF
--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -2084,8 +2084,7 @@ export default {
           context.loading.migrationUpdate = false;
           context.loading.abortAction = false;
           context.migrationReadApps();
-        },
-        false
+        }
       );
     },
     toggleSkip(app) {


### PR DESCRIPTION
Ensure the abort action in the Dashboard correctly handles the migration log with sudo rights.

https://github.com/NethServer/dev/issues/7449