### PR TITLE
Update bind.env to webtop 1.4.4

### DIFF
--- a/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-webtop5/bind.env
+++ b/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-webtop5/bind.env
@@ -1,3 +1,3 @@
 # This file is included by ns8-bind-app
 MODULE_VOLUMES="webtop-home z-push_state"
-MODULE_IMAGE_URL="webtop"
+MODULE_IMAGE_URL="ghcr.io/nethserver/webtop:1.5.0"

--- a/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-webtop5/bind.env
+++ b/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-webtop5/bind.env
@@ -1,3 +1,3 @@
 # This file is included by ns8-bind-app
 MODULE_VOLUMES="webtop-home z-push_state"
-MODULE_IMAGE_URL="ghcr.io/nethserver/webtop:1.4.3"
+MODULE_IMAGE_URL="ghcr.io/nethserver/webtop:1.4.4"

--- a/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-webtop5/bind.env
+++ b/root/usr/share/nethesis/nethserver-ns8-migration/apps/nethserver-webtop5/bind.env
@@ -1,3 +1,3 @@
 # This file is included by ns8-bind-app
 MODULE_VOLUMES="webtop-home z-push_state"
-MODULE_IMAGE_URL="ghcr.io/nethserver/webtop:1.5.0"
+MODULE_IMAGE_URL="ghcr.io/nethserver/webtop:1.4.3"


### PR DESCRIPTION
This pull request updates the image URL for the `webtop` module in the `bind.env` configuration file to use a specific version to avoid the posgresql upgrade directly
The Upgrade from 9 to postgres 17 fails in the import-module action

https://github.com/NethServer/dev/issues/7489