### PR TITLE
fix: preserve never-expires password accounts in exported LDIF

### DIFF
--- a/root/usr/share/nethesis/nethserver-ns8-migration/apps/account-provider/ldap/ns8fixschema.py3
+++ b/root/usr/share/nethesis/nethserver-ns8-migration/apps/account-provider/ldap/ns8fixschema.py3
@@ -165,7 +165,8 @@ def run_filter():
                 # Convert the last password change timestamp:
                 if 'posixAccount' in cur_classes:
                     shadow_last_change = _get_attribute(cur_entry, 'shadowLastChange')
-                    if shadow_last_change:
+                    has_password_never_expires = _get_attribute(cur_entry, 'shadowMax') == '99999'
+                    if shadow_last_change and not has_password_never_expires:
                         try:
                             print('pwdChangedTime: ' + _convert_pwd_change_date(int(shadow_last_change)))
                         except Exception as ex:


### PR DESCRIPTION
When shadowMax is 99999, suppress pwdChangedTime so the NS8 import procedure marks the entry with the neverexpires ppolicy.

Refs NethServer/dev#7981